### PR TITLE
Provide JSON structure and individual error IDs to Cryptol errors

### DIFF
--- a/cryptol-remote-api/src/CryptolServer.hs
+++ b/cryptol-remote-api/src/CryptolServer.hs
@@ -37,7 +37,7 @@ runModuleCmd cmd =
            do setState (set moduleEnv newEnv s)
               return x
 
-data LoadedModule = LoadedMoodule
+data LoadedModule = LoadedModule
   { _loadedName :: Maybe ModName   -- ^ Working on this module.
   , _loadedPath :: FilePath        -- ^ Working on this file.
   }

--- a/cryptol-remote-api/src/CryptolServer.hs
+++ b/cryptol-remote-api/src/CryptolServer.hs
@@ -83,13 +83,13 @@ validateServerState =
 -- The schema for translating Cryptol errors/warnings into JSONRPCExceptions
 
 -- Reserved range for Cryptol exceptions: 20,000 - 21,000
-cryptolErrorPrefix :: Integer
-cryptolErrorPrefix = 20000
+cryptolErrorBase :: Integer
+cryptolErrorBase = 20000
 
 cryptolError :: ModuleError -> [ModuleWarning] -> JSONRPCException
 cryptolError err warns =
   makeJSONRPCException
-    (cryptolErrorPrefix + errorNum)
+    (cryptolErrorBase + errorNum)
     (Text.pack $ (pretty err) <> foldMap (\w -> "\n" <> pretty w) warns)
     (Just . JSON.object $ errorData ++ [("warnings", moduleWarnings warns)])
   where

--- a/cryptol-remote-api/src/CryptolServer.hs
+++ b/cryptol-remote-api/src/CryptolServer.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE NoMonomorphismRestriction #-}
+
 module CryptolServer where
 
 import Control.Exception
@@ -22,7 +22,7 @@ import Cryptol.ModuleSystem.Env
 import Cryptol.ModuleSystem.Fingerprint
 import Cryptol.Parser.AST (ModName)
 import Cryptol.Utils.Logger (quietLogger)
-import Cryptol.Utils.PP (pretty)
+import Cryptol.Utils.PP (pretty, PP)
 
 import Argo
 
@@ -177,7 +177,16 @@ cryptolError err warns =
                 RenamerWarnings rnwarns ->
                   map jsonPretty rnwarns)
 
+    -- Some little helpers for common ways of building JSON values in the above:
+
+    jsonString :: String -> JSON.Value
     jsonString = JSON.String . Text.pack
+
+    jsonPretty :: PP a => a -> JSON.Value
     jsonPretty = jsonString . pretty
+
+    jsonShow :: Show a => a -> JSON.Value
     jsonShow = jsonString . show
+
+    jsonList :: [JSON.Value] -> JSON.Value
     jsonList = JSON.Array . Vector.fromList


### PR DESCRIPTION
The structure currently represented only goes one level deep—contained errors (notably parse, renamer, and type errors) are embedded as lists of `pretty`ed strings. In future, this could easily be altered to provide deeper structure—should this PR be merged before then?