### PR TITLE
WIP: Proof dashboard

### DIFF
--- a/python/saw/__init__.py
+++ b/python/saw/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import argo
 import argo.connection as ac
 import argo.interaction
@@ -55,7 +56,14 @@ class SAWConnection:
                     contract : Any,
                     tactic : str,
                     lemma_name : str) -> argo.interaction.Command:
-        self.most_recent_result = LLVMVerify(self, module, function, lemmas, check_sat, contract, tactic, lemma_name)
+        # find location of function call
+        calling_frame = inspect.currentframe().f_back
+        filename = calling_frame.f_code.co_filename
+        line     = calling_frame.f_lineno
+        location = (filename, line)
+
+        self.most_recent_result = \
+            LLVMVerify(self, module, function, lemmas, check_sat, contract, tactic, lemma_name, location)
         return self.most_recent_result
 
     def llvm_assume(self,

--- a/python/saw/__init__.py
+++ b/python/saw/__init__.py
@@ -9,10 +9,11 @@ from saw.commands import *
 from typing import Optional
 
 
-def connect(command : str, cryptol_path : Optional[str] = None) -> SAWConnection:
+def connect(command : str,
+            delay_verification_exceptions : Optional[bool] = False) -> SAWConnection:
     proc = ac.ServerProcess(command)
     conn = ac.ServerConnection(proc)
-    return SAWConnection(conn)
+    return SAWConnection(conn, delay_verification_exceptions)
 
 
 class SAWConnection:
@@ -20,9 +21,14 @@ class SAWConnection:
 
     most_recent_result : Optional[argo.interaction.Interaction]
 
-    def __init__(self, server_connection : ac.ServerConnection) -> None:
+    def __init__(self,
+                 server_connection : ac.ServerConnection,
+                 delay_verification_exceptions : Optional[bool] = False) -> None:
         self.most_recent_result = None
         self.server_connection = server_connection
+        self._verifications : Optional[List[Tuple[str, int, Dict[str, str], bool]]] = None
+        if delay_verification_exceptions:
+            self._verifications = []
 
     def snapshot(self) -> SAWConnection:
         """Return a ``SAWConnection`` that has the same process and state as
@@ -31,7 +37,46 @@ class SAWConnection:
         """
         copy = SAWConnection(self.server_connection)
         copy.most_recent_result = self.most_recent_result
+        if self._verifications is not None:
+            copy._verifications = self._verifications[:] # shallow copy of list spine
         return copy
+
+    def summary(self) ->  Optional[List[Tuple[str, int, Dict[str, str], bool]]]:
+        """Return a summary of the verification results from this session so far, in
+        the form of a list of (optional filename, optional line number, method
+        parameters, verification result) tuples
+        """
+        if self._verifications is not None:
+            return self._verifications[:]
+        else:
+            return None
+
+    def assert_all_verifications(self) -> None:
+        """Assert that all verifications so far have been correct; if not, throw an
+        AssertionError containing the human-readable summary of the verifications"""
+        readable_summary = self.readable_summary()
+        if readable_summary is not None:
+            (ok, summary) = readable_summary
+            if not ok:
+                raise AssertionError(summary)
+
+    def readable_summary(self) -> Optional[Tuple[bool, str]]:
+        """Return a human-readable summary of the verification results from this
+        session so far.
+        """
+        if self._verifications is None:
+            return None
+        ok = True
+        output = ""
+        for (filename, line, params, result) in self._verifications:
+            ok = ok and result
+            if result:
+                mark = '\033[1;32m✔\033[1;0m'
+            else:
+                mark = '\033[1;31m✘\033[1;0m'
+            output_line = mark + " " + filename + ":" + str(line) + ": '" + params['lemma name'] + "'"
+            output += output_line + "\n"
+        return (ok, output)
 
     def protocol_state(self) -> Any:
         if self.most_recent_result is None:
@@ -56,14 +101,19 @@ class SAWConnection:
                     contract : Any,
                     tactic : str,
                     lemma_name : str) -> argo.interaction.Command:
-        # find location of function call
-        calling_frame = inspect.currentframe().f_back
-        filename = calling_frame.f_code.co_filename
-        line     = calling_frame.f_lineno
-        location = (filename, line)
+        # Determine the location of this verification call: either where the
+        # command was created, or the passed-in location
+        filename : Optional[str] = None
+        line     : Optional[int] = None
+        location : Optional[Tuple[str, int]] = None
+        calling_frame = inspect.currentframe()
+        if calling_frame is not None:
+            filename = calling_frame.f_back.f_code.co_filename
+            line     = calling_frame.f_back.f_lineno
+            location = (filename, line)
 
         self.most_recent_result = \
-            LLVMVerify(self, module, function, lemmas, check_sat, contract, tactic, lemma_name, location)
+            LLVMVerify(self, module, function, lemmas, check_sat, contract, tactic, lemma_name, self._verifications, location)
         return self.most_recent_result
 
     def llvm_assume(self,

--- a/python/saw/commands.py
+++ b/python/saw/commands.py
@@ -1,7 +1,8 @@
 import argo.interaction
+import inspect
 from argo.interaction import HasProtocolState
 
-from typing import Any, List
+from typing import Any, List, Optional, Tuple
 
 class CryptolLoadFile(argo.interaction.Command):
     def __init__(self, connection : HasProtocolState, filename : str) -> None:
@@ -65,7 +66,8 @@ class LLVMVerify(argo.interaction.Command):
             check_sat : bool,
             setup : Any,
             tactic : str,
-            lemma_name : str) -> None:
+            lemma_name : str,
+            location : Optional[Tuple[str, int]] = None) -> None:
         params = {'module': module,
                   'function': function,
                   'lemmas': lemmas,
@@ -73,6 +75,13 @@ class LLVMVerify(argo.interaction.Command):
                   'contract': setup,
                   'tactic': tactic,
                   'lemma name': lemma_name}
+        if location is None:
+            calling_frame = inspect.currentframe().f_back
+            self.filename = calling_frame.f_code.co_filename
+            self.line     = calling_frame.f_lineno
+        else:
+            self.filename = location[0]
+            self.line     = location[1]
         super(LLVMVerify, self).__init__('SAW/LLVM/verify', params, connection)
 
     def process_result(self, _res : Any) -> Any:

--- a/python/saw/commands.py
+++ b/python/saw/commands.py
@@ -2,7 +2,7 @@ import argo.interaction
 import inspect
 from argo.interaction import HasProtocolState
 
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Optional, Tuple, Dict
 
 class CryptolLoadFile(argo.interaction.Command):
     def __init__(self, connection : HasProtocolState, filename : str) -> None:
@@ -67,6 +67,7 @@ class LLVMVerify(argo.interaction.Command):
             setup : Any,
             tactic : str,
             lemma_name : str,
+            verifications : Optional[List[Tuple[str, int, Dict[str, str], bool]]] = None,
             location : Optional[Tuple[str, int]] = None) -> None:
         params = {'module': module,
                   'function': function,
@@ -75,14 +76,32 @@ class LLVMVerify(argo.interaction.Command):
                   'contract': setup,
                   'tactic': tactic,
                   'lemma name': lemma_name}
+        self.params = params
+        # Determine the location of this verification call: either where the
+        # command was created, or the passed-in location
+        self.filename : Optional[str] = None
+        self.line     : Optional[int] = None
         if location is None:
-            calling_frame = inspect.currentframe().f_back
-            self.filename = calling_frame.f_code.co_filename
-            self.line     = calling_frame.f_lineno
+            calling_frame = inspect.currentframe()
+            if calling_frame is not None:
+                self.filename = calling_frame.f_back.f_code.co_filename
+                self.line     = calling_frame.f_back.f_lineno
         else:
             self.filename = location[0]
             self.line     = location[1]
+        self.verifications = verifications
         super(LLVMVerify, self).__init__('SAW/LLVM/verify', params, connection)
 
     def process_result(self, _res : Any) -> Any:
-        return None
+        if self.verifications is not None:
+            if self.filename is not None and self.line is not None:
+                self.verifications.append((self.filename, self.line, self.params, True))
+        return True
+
+    def process_error(self, code : int, data : Any, msg : str) -> Any:
+        if (self.verifications is not None) and ((code >= 10300) and (code < 20000)):
+            if self.filename is not None and self.line is not None:
+                self.verifications.append((self.filename, self.line, self.params, False))
+            return False
+        else:
+            return None


### PR DESCRIPTION
This is a work-in-progress to support a "proof dashboard" to address #28. Currently, an extension of the `SAWConnection` API enables the following style of proof:

```python
c = saw.connect("cabal new-exec --verbose=0 saw-remote-api -- --dynamic4",
                delay_verification_exceptions = True)
...
c.llvm_verify(...).result()
...
c.assert_all_verifications()
```

When the script is run, if any of the `.llvm_verify` commands in that session failed, the final line will throw an `AssertionError` with a pretty-printed message describing all the verifications in the file.

This pretty-printed list of verifications (which includes both valid and invalid ones) can be accessed using the `.readable_summary()` method of a `SAWConnection`; a structured log can be gotten using the `.summary()` method.

Note when using this that there is "magic" Pythonic introspection happening: we get filename and line number information for the calls to `llvm_verify` "out of thin air." This functionality may be something we want to delegate to a higher-level API before merging—specifically, the yet-to-be-created "synchronous" API which automatically inserts calls to `.result()`.