### PR TITLE
Cabal test mypy

### DIFF
--- a/python/argo-python.cabal
+++ b/python/argo-python.cabal
@@ -18,3 +18,17 @@ library
   hs-source-dirs:    hs
   exposed-modules:   Argo.PythonBindings
   other-modules:     Paths_argo_python
+
+test-suite test-argo-python
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      hs-test
+  main-is:             Main.hs
+  other-modules:       Paths_argo_python
+  build-depends:       base,
+                       argo-python,
+                       filepath,
+                       directory,
+                       tasty,
+                       tasty-hunit,
+                       tasty-quickcheck,
+                       tasty-script-exitcode

--- a/python/hs-test/Main.hs
+++ b/python/hs-test/Main.hs
@@ -1,0 +1,34 @@
+module Main where
+
+import System.FilePath ((</>), takeBaseName)
+import System.Directory
+import Data.Traversable
+import Control.Monad
+
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Tasty.HUnit.ScriptExit
+
+import Paths_argo_python
+import Argo.PythonBindings
+
+main :: IO ()
+main =
+  do reqs <- getArgoPythonFile "requirements.txt"
+     withPython3venv (Just reqs) $ \pip python ->
+       do pySrc <- getArgoPythonFile "."
+          pip ["install", pySrc]
+
+          thisDirectory <- getDataFileName "."
+
+          subdirectories <-
+            do paths <- listDirectory thisDirectory
+               filterM (doesDirectoryExist . ("." </>)) paths
+
+          allTests <- for subdirectories $ \dir ->
+            do let name = takeBaseName dir
+               tests <- makeScriptTests dir [mypy]
+               pure (testGroup ("Typechecking: " <> name) tests)
+
+          defaultMain $
+            testGroup "Tests for Python components" allTests

--- a/python/saw/__init__.py
+++ b/python/saw/__init__.py
@@ -15,7 +15,7 @@ class SAWConnection:
 
     most_recent_result : Optional[argo.interaction.Interaction]
 
-    def __init__(self, command_or_connection : Union[str, ServerProcess]) -> None:
+    def __init__(self, command_or_connection : Union[str, ac.ServerConnection]) -> None:
         self.most_recent_result = None
         if isinstance(command_or_connection, str):
             self.proc = ac.ServerProcess(command_or_connection)


### PR DESCRIPTION
Fixes #42. Along the way:

* The limitation on one-to-one extension to `TestLang` mapping has been lifted: many `TestLang`s can be defined for any given file extension and all will be considered.
* MyPy has been added as a `TestLang` in the `tasty-script-exitcode` package.