### PR TITLE
Add a --public flag to bind a public socket

### DIFF
--- a/argo/argo.cabal
+++ b/argo/argo.cabal
@@ -33,6 +33,7 @@ common deps
     lens                        ^>= 4.17,
     mtl                         ^>= 2.2,
     network                     ^>= 3.0.1,
+    optparse-applicative        ^>= 0.14,
     scientific                  ^>= 0.3,
     scotty                      ^>= 0.11.3,
     text                        ^>= 1.2.3,
@@ -43,9 +44,10 @@ common deps
 library
   import: deps, warnings
   exposed-modules:
-    Argo.CacheTree
-    Argo.HistoryWrapper
     Argo
+    Argo.CacheTree
+    Argo.DefaultMain
+    Argo.HistoryWrapper
     Argo.Socket
     Argo.Netstring
   hs-source-dirs: src

--- a/argo/src/Argo/DefaultMain.hs
+++ b/argo/src/Argo/DefaultMain.hs
@@ -1,0 +1,98 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Argo.DefaultMain (defaultMain) where
+
+
+import Control.Applicative
+import Control.Concurrent.Async (wait)
+import Network.Socket (HostName)
+import qualified Options.Applicative as Opt
+import System.Exit (die)
+import System.IO (BufferMode(..), hSetBuffering, stdout)
+
+import Argo
+import Argo.Socket
+
+
+defaultMain :: String -> App s -> IO ()
+defaultMain str app =
+  do opts <- Opt.execParser (options str)
+     realMain app opts
+
+data Options =
+  Options
+    { transportOpt :: TransportOpt
+    , publicityOpt :: Maybe Publicity
+    }
+
+newtype Port = Port String
+
+data TransportOpt
+  = StdIONetstring               -- ^ NetStrings over standard IO
+  | SocketNetstring Port         -- ^ NetStrings over specific port (all hosts)
+  | SocketNetstringDyn IPVersion -- ^ NetStrings over specific IP version (dynamic port)
+
+data Publicity
+  = Public
+
+data IPVersion
+  = IPv6 | IPv4
+
+options :: String -> Opt.ParserInfo Options
+options desc =
+  Opt.info ((Options <$> transport <*> publicity) <**> Opt.helper) $
+  Opt.fullDesc <> Opt.progDesc desc
+
+transport :: Opt.Parser TransportOpt
+transport = dyn4 <|> dyn6 <|> socket <|> stdio <|> pure StdIONetstring
+  where
+    socket = SocketNetstring . Port <$>
+             Opt.strOption (Opt.long "socket" <>
+                            Opt.metavar "PORT" <>
+                            Opt.help "Use netstrings over a socket on PORT to communicate")
+
+    stdio  = Opt.flag' StdIONetstring $
+             Opt.long "stdio" <> Opt.help "Use netstrings over stdio to communicate"
+
+    dyn4   = Opt.flag' (SocketNetstringDyn IPv4) $
+             Opt.long "dynamic4" <>
+             Opt.help "Dynamically choose an IPv4 port on which to communicate using netstrings, and write it to stdout."
+
+    dyn6   = Opt.flag' (SocketNetstringDyn IPv6) $
+             Opt.long "dynamic" <>
+             Opt.help "Dynamically choose an IPv6 port on which to communicate using netstrings, and write it to stdout."
+
+publicity :: Opt.Parser (Maybe Publicity)
+publicity =
+  Opt.flag Nothing (Just Public) $
+  Opt.long "public" <> Opt.help "Run the server publicly"
+
+
+validateOpts :: Options -> IO ()
+validateOpts theOpts =
+  case (transportOpt theOpts, publicityOpt theOpts) of
+    (StdIONetstring, Just Public) ->
+      die "A server on stdio cannot be public."
+    _ ->
+      pure ()
+
+selectHost :: IPVersion -> Maybe Publicity -> HostName
+selectHost IPv6 Nothing = "::1"
+selectHost IPv4 Nothing = "127.0.0.1"
+selectHost IPv6 (Just Public) = "::"
+selectHost IPv4 (Just Public) = "0.0.0.0"
+
+
+realMain :: App s -> Options -> IO ()
+realMain theApp opts =
+  do validateOpts opts
+     case transportOpt opts of
+       StdIONetstring ->
+         serveStdIONS theApp
+       SocketNetstring (Port p) ->
+         serveSocket (selectHost IPv4 (publicityOpt opts)) p theApp
+       SocketNetstringDyn ip ->
+         do hSetBuffering stdout NoBuffering
+            let h = selectHost ip (publicityOpt opts)
+            (a, p) <- serveSocketDynamic h theApp
+            putStrLn ("PORT " ++ show p)
+            wait a

--- a/cryptol-remote-api/cryptol-remote-api.cabal
+++ b/cryptol-remote-api/cryptol-remote-api.cabal
@@ -67,8 +67,6 @@ executable cryptol-remote-api
 
   build-depends:
     cryptol-remote-api,
-    optparse-applicative ^>= 0.14,
-    async                ^>= 2.2.1,
     sbv
 
 test-suite test-cryptol-remote-api

--- a/cryptol-remote-api/cryptol-remote-api/Main.hs
+++ b/cryptol-remote-api/cryptol-remote-api/Main.hs
@@ -3,19 +3,16 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 module Main (main) where
 
-import Control.Applicative
-import Control.Concurrent.Async (wait)
 import qualified Data.Aeson as JSON
 import Data.Text (Text)
-import qualified Options.Applicative as Opt
 import System.Environment (lookupEnv)
 import System.FilePath (splitSearchPath)
-import System.IO (stdout, hSetBuffering, BufferMode(..))
 
 import Argo
-import Argo.Socket
-import Argo.HistoryWrapper
 import Argo.CacheTree
+import Argo.DefaultMain
+import Argo.HistoryWrapper
+
 
 import CryptolServer
 import CryptolServer.Call
@@ -29,55 +26,19 @@ import CryptolServer.TypeCheck
 
 main :: IO ()
 main =
-  do opts <- Opt.execParser options
-     realMain opts
-
-newtype Options =
-  Options { transportOpt :: TransportOpt }
-
-newtype Port = Port String
-
-data TransportOpt
-  = StdIONetstring              -- ^ NetStrings over standard IO
-  | SocketNetstring Port        -- ^ NetStrings over specific port (all hosts)
-  | SocketNetstringDyn String   -- ^ NetStrings over specific host (dynamic port)
-
-options :: Opt.ParserInfo Options
-options = Opt.info (Options <$> transport) (Opt.fullDesc)
-
-transport :: Opt.Parser TransportOpt
-transport = dyn4 <|> dyn6 <|> socket <|> stdio <|> pure StdIONetstring
-  where
-    socket      = SocketNetstring . Port <$>
-                    Opt.strOption (Opt.long "socket" <> Opt.metavar "PORT" )
-
-    stdio       = Opt.flag' StdIONetstring (Opt.long "stdio" <> Opt.help "Use netstrings over stdio")
-
-    dyn4        = Opt.flag' (SocketNetstringDyn "127.0.0.1") (Opt.long "dynamic4")
-
-    dyn6        = Opt.flag' (SocketNetstringDyn "::1"      ) (Opt.long "dynamic")
-
-
-getSearchPaths :: IO [FilePath]
-getSearchPaths =
-  maybe [] splitSearchPath <$> lookupEnv "CRYPTOLPATH"
-
-
-realMain :: Options -> IO ()
-realMain opts =
   do paths <- getSearchPaths
      initSt <- setSearchPath paths <$> initialState
      cache  <- newCache initSt
      theApp <- mkApp (HistoryWrapper cache) (historyWrapper validateServerState cryptolMethods)
-     case transportOpt opts of
-       StdIONetstring -> serveStdIONS theApp
-       SocketNetstring (Port p) -> serveSocket "127.0.0.1" p theApp
-       SocketNetstringDyn h ->
-         do hSetBuffering stdout NoBuffering
-            (a, p) <- serveSocketDynamic h theApp
-            putStrLn ("PORT " ++ show p)
-            wait a
+     defaultMain description theApp
 
+description :: String
+description =
+  "An RPC server for Cryptol that supports type checking and evaluation of Cryptol code."
+
+getSearchPaths :: IO [FilePath]
+getSearchPaths =
+  maybe [] splitSearchPath <$> lookupEnv "CRYPTOLPATH"
 
 cryptolMethods :: [(Text, MethodType, JSON.Value -> Method ServerState JSON.Value)]
 cryptolMethods =

--- a/saw-remote-api/saw-remote-api.cabal
+++ b/saw-remote-api/saw-remote-api.cabal
@@ -79,9 +79,7 @@ library
 executable saw-remote-api
   import: deps, warnings
   main-is:             Main.hs
-  build-depends:       async                ^>= 2.2.1,
-                       optparse-applicative ^>= 0.14,
-                       saw-remote-api
+  build-depends:       saw-remote-api
   -- other-modules:
   -- other-extensions:
   hs-source-dirs: saw-remote-api

--- a/saw-remote-api/saw-remote-api/Main.hs
+++ b/saw-remote-api/saw-remote-api/Main.hs
@@ -1,17 +1,13 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Main (main) where
 
-import Control.Applicative
-import Control.Concurrent.Async (wait)
 import qualified Data.Aeson as JSON
 import Data.Text (Text)
-import qualified Options.Applicative as Opt
-import System.IO (BufferMode(..), hSetBuffering, stdout)
 
 import Argo
-import Argo.Socket
-import Argo.HistoryWrapper
 import Argo.CacheTree
+import Argo.DefaultMain
+import Argo.HistoryWrapper
 
 import SAWServer
 import SAWServer.CryptolSetup
@@ -23,53 +19,14 @@ import SAWServer.SaveTerm
 
 main :: IO ()
 main =
-  do opts <- Opt.execParser options
-     realMain opts
-
-
-data Options =
-  Options
-    { transportOpt :: TransportOpt
-    }
-
-newtype Port = Port String
-
-data TransportOpt
-  = StdIONetstring              -- ^ NetStrings over standard IO
-  | SocketNetstring Port        -- ^ NetStrings over specific port (all hosts)
-  | SocketNetstringDyn String   -- ^ NetStrings over specific host (dynamic port)
-
-options :: Opt.ParserInfo Options
-options = Opt.info (Options <$> transport) (Opt.fullDesc)
-
-transport :: Opt.Parser TransportOpt
-transport = dyn4 <|> dyn6 <|> socket <|> stdio <|> pure StdIONetstring
-  where
-    socket      = SocketNetstring . Port <$>
-                    Opt.strOption (Opt.long "socket" <> Opt.metavar "PORT" )
-
-    stdio       = Opt.flag' StdIONetstring (Opt.long "stdio" <> Opt.help "Use netstrings over stdio")
-
-    dyn4        = Opt.flag' (SocketNetstringDyn "127.0.0.1") (Opt.long "dynamic4")
-
-    dyn6        = Opt.flag' (SocketNetstringDyn "::1"      ) (Opt.long "dynamic")
-
-
-
-
-realMain :: Options -> IO ()
-realMain opts =
   do initSt <- initialState
      cache  <- newCache initSt
      theApp <- mkApp (HistoryWrapper cache) (historyWrapper validateSAWState sawMethods)
-     case transportOpt opts of
-       StdIONetstring -> serveStdIONS theApp
-       SocketNetstring (Port p) -> serveSocket "127.0.0.1" p theApp
-       SocketNetstringDyn h ->
-         do hSetBuffering stdout NoBuffering
-            (a, p) <- serveSocketDynamic h theApp
-            putStrLn ("PORT " ++ show p)
-            wait a
+     defaultMain description theApp
+
+description :: String
+description =
+  "An RPC server for SAW."
 
 sawMethods :: [(Text, MethodType, JSON.Value -> Method SAWState JSON.Value)]
 sawMethods =


### PR DESCRIPTION
While doing this, the substantially similar main actions in both servers were consolidated into one, reducing duplication, and the usage information blurb was greatly improved.