### PR TITLE
WIP: Travis updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,14 @@ cache:
 git:
   submodules: false
 
+python:
+  - "3.7"
 
 matrix:
   include:
     - env: CABALVER="3.0" GHCVER="8.6.5"
       compiler: ": #GHC 8.6.5"
       addons: {apt: {packages: [cabal-install-3.0,ghc-8.6.5,python3-venv], sources: [hvr-ghc]}}
-      python: 3.7
 #    - env: CABALVER="3.0" GHCVER="8.4.4"
 #      compiler: ": #GHC 8.4.4"
 #      addons: {apt: {packages: [cabal-install-3.0,ghc-8.4.4], sources: [hvr-ghc]}}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 dist: bionic
 
-language: c
+language: python
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ before_install:
 script:
   - git submodule init
   - git submodule update
+  - which python
+  - which python2
   - (cd deps/abcBridge && git submodule init && git submodule update)
   - cabal v2-update
   - cabal v2-build -j --disable-optimization cryptol-remote-api

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,13 @@ cache:
 git:
   submodules: false
 
+
 matrix:
   include:
     - env: CABALVER="3.0" GHCVER="8.6.5"
       compiler: ": #GHC 8.6.5"
       addons: {apt: {packages: [cabal-install-3.0,ghc-8.6.5,python3-venv], sources: [hvr-ghc]}}
+      python: 3.7
 #    - env: CABALVER="3.0" GHCVER="8.4.4"
 #      compiler: ": #GHC 8.4.4"
 #      addons: {apt: {packages: [cabal-install-3.0,ghc-8.4.4], sources: [hvr-ghc]}}

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
   - unset CC
   - export PATH=/opt/ghc/bin:$HOME/.cabal/bin:$PATH
   - which python3
-  - update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7
+  - update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 100
 
 script:
   - git submodule init

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 dist: bionic
 
-language: python
+language: c
 
 cache:
   directories:
@@ -14,14 +14,12 @@ cache:
 git:
   submodules: false
 
-python:
-  - "3.7"
 
 matrix:
   include:
     - env: CABALVER="3.0" GHCVER="8.6.5"
       compiler: ": #GHC 8.6.5"
-      addons: {apt: {packages: [cabal-install-3.0,ghc-8.6.5,python3-venv], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-3.0,ghc-8.6.5,python3.7,python3.7-venv], sources: [hvr-ghc]}}
 #    - env: CABALVER="3.0" GHCVER="8.4.4"
 #      compiler: ": #GHC 8.4.4"
 #      addons: {apt: {packages: [cabal-install-3.0,ghc-8.4.4], sources: [hvr-ghc]}}
@@ -29,12 +27,14 @@ matrix:
 before_install:
   - unset CC
   - export PATH=/opt/ghc/bin:$HOME/.cabal/bin:$PATH
+  - update-alternatives --set python3 /usr/bin/python3.7
 
 script:
   - git submodule init
   - git submodule update
   - which python
-  - which python2
+  - which python3
+  - python3 -m pip 
   - (cd deps/abcBridge && git submodule init && git submodule update)
   - cabal v2-update
   - cabal v2-build -j --disable-optimization cryptol-remote-api

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,8 @@ before_install:
   - unset CC
   - export PATH=/opt/ghc/bin:$HOME/.cabal/bin:$PATH
   - which python3
-  - update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 100
+  - deactivate
+  - which python3
 
 script:
   - git submodule init

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,8 @@ matrix:
 before_install:
   - unset CC
   - export PATH=/opt/ghc/bin:$HOME/.cabal/bin:$PATH
-  - update-alternatives --set python3 /usr/bin/python3.7
+  - which python3
+  - update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7
 
 script:
   - git submodule init

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-dist: trusty
-sudo: false
+dist: bionic
 
 language: c
 
@@ -15,13 +14,11 @@ cache:
 git:
   submodules: false
 
-addons: {apt: {packages: [python3-venv]}}
-
 matrix:
   include:
     - env: CABALVER="3.0" GHCVER="8.6.5"
       compiler: ": #GHC 8.6.5"
-      addons: {apt: {packages: [cabal-install-3.0,ghc-8.6.5], sources: [hvr-ghc]}}
+      addons: {apt: {packages: [cabal-install-3.0,ghc-8.6.5,python3-venv], sources: [hvr-ghc]}}
 #    - env: CABALVER="3.0" GHCVER="8.4.4"
 #      compiler: ": #GHC 8.4.4"
 #      addons: {apt: {packages: [cabal-install-3.0,ghc-8.4.4], sources: [hvr-ghc]}}


### PR DESCRIPTION
 - Pick newest Ubuntu LTS (trusty is EOL now)
 - Container-based infrastructure is deprecated, so don't request it

This is to see if we can get it working again.
