### PR TITLE
Feature/saw track files

### DIFF
--- a/saw-remote-api/saw-remote-api.cabal
+++ b/saw-remote-api/saw-remote-api.cabal
@@ -43,6 +43,7 @@ common deps
                  cryptol-verifier,
                  crucible,
                  crucible-jvm,
+                 cryptonite,
                  directory,
                  jvm-verifier,
                  lens,

--- a/saw-remote-api/saw-remote-api.cabal
+++ b/saw-remote-api/saw-remote-api.cabal
@@ -44,6 +44,7 @@ common deps
                  crucible,
                  crucible-jvm,
                  cryptonite,
+                 cryptonite-conduit,
                  directory,
                  jvm-verifier,
                  lens,
@@ -76,6 +77,7 @@ library
                    SAWServer.SetupValue,
                    SAWServer.Term,
                    SAWServer.TopLevel
+                   SAWServer.TrackFile
 
 executable saw-remote-api
   import: deps, warnings

--- a/saw-remote-api/src/SAWServer.hs
+++ b/saw-remote-api/src/SAWServer.hs
@@ -172,6 +172,12 @@ initialState =
                 }
      return (SAWState emptyEnv bic [] ro rw M.empty)
 
+-- NOTE: KWF: 2020-04-22: This function could introduce a race condition: if a
+-- file changes on disk after its hash is computed by validateSAWState, but
+-- before the function returns and its result is used to inform whether to
+-- recompute a cached result, the cached result may be used even if it is
+-- associated with stale filesystem state. See the discussion of this issue at:
+-- https://github.com/GaloisInc/argo/pull/70#discussion_r412462908
 validateSAWState :: SAWState -> IO Bool
 validateSAWState sawState =
   checkAll

--- a/saw-remote-api/src/SAWServer.hs
+++ b/saw-remote-api/src/SAWServer.hs
@@ -176,7 +176,7 @@ validateSAWState :: SAWState -> IO Bool
 validateSAWState sawState =
   checkAll
     [ CryptolServer.validateServerState cryptolState
-    , checkAll $ uncurry checkHash <$> M.assocs (view trackedFiles sawState)
+    , checkAll $ map (uncurry checkHash) (M.assocs (view trackedFiles sawState))
     ]
   where
     checkAll [] = pure True

--- a/saw-remote-api/src/SAWServer/LLVMCrucibleSetup.hs
+++ b/saw-remote-api/src/SAWServer/LLVMCrucibleSetup.hs
@@ -53,6 +53,7 @@ import SAWServer.Data.LLVMType (JSONLLVMType, llvmType)
 import SAWServer.CryptolExpression (getTypedTermOfCExp)
 import SAWServer.Exceptions
 import SAWServer.OK
+import SAWServer.TrackFile
 import SAWServer.SetupValue ()
 
 data Contract cryptolExpr =
@@ -237,4 +238,5 @@ llvmLoadModule (LLVMLoadModuleParams serverName fileName) =
               Left err -> raise (cantLoadLLVMModule (LLVM.formatError err))
               Right llvmMod ->
                 do setServerVal serverName llvmMod
+                   trackFile fileName
                    ok

--- a/saw-remote-api/src/SAWServer/TrackFile.hs
+++ b/saw-remote-api/src/SAWServer/TrackFile.hs
@@ -1,0 +1,24 @@
+module SAWServer.TrackFile (trackFile, forgetFile) where
+
+import Control.Lens
+import qualified Data.Map as M
+import qualified Crypto.Hash.Conduit as Hash
+
+import Argo
+import SAWServer
+
+-- | Add a filepath to the list of filepaths tracked by the server. Any change
+-- to the SHA256 hash of this file will invalidate any cached state which is
+-- causally descended from the moment this method is invoked, unless
+-- @forgetFile@ is used to remove tracking of this file.
+trackFile :: FilePath -> Method SAWState ()
+trackFile path =
+  do hash <- Hash.hashFile path
+     modifyState $ over trackedFiles (M.insert path hash)
+
+-- | Stop tracking a given file. Any state that causally descends from the
+-- moment this method is invoked will not be invalidated by changes to the file
+-- on disk, even if this file was previously tracked via @trackFile@.
+forgetFile :: FilePath -> Method SAWState ()
+forgetFile path =
+  modifyState $ over trackedFiles (M.delete path)


### PR DESCRIPTION
This fixes #27 by implementing file hash tracking for LLVM modules loaded, which can be extended to any file we choose to manipulate on disk in the future.

Unlike in Cryptol, loaded LLVM modules in SAW are not associated with a file fingerprint when they are loaded, so we supply this checksum functionality storing a SHA256 hash in an added `Map FilePath (Digest SHA256)` in the `SAWState` for the server.