### PR TITLE
Feature/persistent server

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,7 +99,7 @@ Python session to give you an idea of what's currently implemented,
 with commentary in the form of Python comments::
 
     $ ipython3 -i cryptol-api_test.py
-    Python 3.7.2 (default, Jan 16 2019, 19:49:22) 
+    Python 3.7.2 (default, Jan 16 2019, 19:49:22)
     Type 'copyright', 'credits' or 'license' for more information
     IPython 6.4.0 -- An enhanced Interactive Python. Type '?' for help.
 
@@ -114,7 +114,7 @@ with commentary in the form of Python comments::
     Docstring:   <no docstring>
 
     In [2]: c.protocol_state()
-    Out[2]: 
+    Out[2]:
     [['change directory', {'directory': '/home/dtc/Projects/proto/proto/python'}],
      ['load module', {'file': 'Foo.cry'}]]
 
@@ -165,7 +165,7 @@ with commentary in the form of Python comments::
     Type:        CryptolFunctionHandle
     String form: <cryptol.CryptolFunctionHandle object at 0x7fa16e87b748>
     File:        ~/Projects/proto/proto/python/cryptol/__init__.py
-    Docstring:  
+    Docstring:
     Cryptol type: {n} (fin n) => [n] -> [n] -> Bit
     Unsigned carry.  Returns true if the unsigned addition of the given
     bitvector arguments would result in an unsigned overflow.
@@ -175,7 +175,7 @@ with commentary in the form of Python comments::
     Type:        CryptolFunctionHandle
     String form: <cryptol.CryptolFunctionHandle object at 0x7fa16e7bb6a0>
     File:        ~/Projects/proto/proto/python/cryptol/__init__.py
-    Docstring:  
+    Docstring:
     Cryptol type: {n} (fin n) => [n] -> [n] -> Bit
     Unsigned carry.  Returns true if the unsigned addition of the given
     bitvector arguments would result in an unsigned overflow.
@@ -205,8 +205,8 @@ To use the stdio version:
 
 1. ``M-x proto-test-start``
 
-2. At the prompt for ``Command:``, run the server with
-   ``cabal v2-exec saw-remote-api`` or ``cabal v2-exec cryptol-remote-api``.
+2. At the prompt for ``Command:``, run the server with ``cabal v2-exec -v0
+   saw-remote-api`` or ``cabal v2-exec -v0 cryptol-remote-api``.
 
 If this leaves a confusing error message in Emacs, the output was
 probably corrupted by ``cabal-install`` stating that nothing needs
@@ -216,7 +216,7 @@ up-to-date, and try again.
 
 To use the socket version:
 
-1. At a shell, run ``cabal v2-exec cryptol-remote-api -- --socket 10006``
+1. At a shell, run ``cabal v2-exec cryptol-remote-api -- --port 10006``
    (or pick your favorite port instead of 10006)
 
 2. In Emacs, ``M-x proto-test-start-socket``. When prompted, enter

--- a/argo/argo.cabal
+++ b/argo/argo.cabal
@@ -23,17 +23,21 @@ common warnings
 
 common deps
   build-depends:
-    base                        >= 4.11.1.0 && < 4.13,
+    base                         >= 4.11.1.0 && < 4.13,
     aeson                       ^>= 1.4.2,
     async                       ^>= 2.2,
     binary                      ^>= 0.8.5.1,
     bytestring                  ^>= 0.10.8,
-    containers                  >=0.5.11 && <0.7,
+    containers                   >= 0.5.11 && <0.7,
+    directory                   ^>= 1.3,
+    filelock                    ^>= 0.1,
+    filepath                    ^>= 1.4,
     hashable                    ^>= 1.2,
     lens                        ^>= 4.17,
     mtl                         ^>= 2.2,
     network                     ^>= 3.0.1,
     optparse-applicative        ^>= 0.14,
+    safe                        ^>= 0.3,
     scientific                  ^>= 0.3,
     scotty                      ^>= 0.11.3,
     text                        ^>= 1.2.3,

--- a/argo/argo.cabal
+++ b/argo/argo.cabal
@@ -40,6 +40,7 @@ common deps
     safe                        ^>= 0.3,
     scientific                  ^>= 0.3,
     scotty                      ^>= 0.11.3,
+    silently                    ^>= 1.2,
     text                        ^>= 1.2.3,
     unordered-containers        ^>= 0.2,
     wai                         ^>= 3.2.2,

--- a/argo/src/Argo/Socket.hs
+++ b/argo/src/Argo/Socket.hs
@@ -74,7 +74,6 @@ startListening addr =
                    (N.addrSocketType addr)
                    (N.addrProtocol   addr)
      N.setSocketOption s N.ReuseAddr 1 -- easier to restart server
-     N.setSocketOption s N.IPv6Only 0 -- serve on both IPv6 and IPv4
      N.bind s (N.addrAddress addr)
      N.listen s listenQueueDepth
      return s

--- a/argo/src/Argo/Socket.hs
+++ b/argo/src/Argo/Socket.hs
@@ -74,6 +74,7 @@ startListening addr =
                    (N.addrSocketType addr)
                    (N.addrProtocol   addr)
      N.setSocketOption s N.ReuseAddr 1 -- easier to restart server
+     N.setSocketOption s N.IPv6Only 0 -- serve on both IPv6 and IPv4
      N.bind s (N.addrAddress addr)
      N.listen s listenQueueDepth
      return s

--- a/cryptol-remote-api/test-scripts/cryptol-api_test.py
+++ b/cryptol-remote-api/test-scripts/cryptol-api_test.py
@@ -6,7 +6,7 @@ import cryptol.cryptoltypes
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
-c = cryptol.connect("cabal new-exec --verbose=0 cryptol-remote-api -- --dynamic4")
+c = cryptol.connect("cabal new-exec --verbose=0 cryptol-remote-api")
 
 c.change_directory(dir_path)
 

--- a/cryptol-remote-api/test-scripts/cryptol-tests.py
+++ b/cryptol-remote-api/test-scripts/cryptol-tests.py
@@ -11,7 +11,7 @@ cryptol_path = dir_path.joinpath('test-data')
 
 c = argo.ServerConnection(
       cryptol.CryptolProcess(
-          "cabal v2-exec cryptol-remote-api  --verbose=0 -- --dynamic4",
+          "cabal v2-exec cryptol-remote-api  --verbose=0",
           cryptol_path=cryptol_path))
 
 # Regression tests on nested sequences

--- a/examples/salsa20.py
+++ b/examples/salsa20.py
@@ -6,7 +6,7 @@ from saw.llvm import Contract, LLVMArrayType, uint8_t, uint32_t, void
 from saw import *
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
-connect("saw-remote-api --dynamic4")
+connect("cabal -v0 v2-run exe:saw-remote-api")
 
 bcname = os.path.join(dir_path, 'salsa20.bc')
 cryname = os.path.join(dir_path, 'Salsa20.cry')

--- a/examples/swap.py
+++ b/examples/swap.py
@@ -29,7 +29,7 @@ class Swap(Contract):
         self.points_to(self.y_pointer, self.x)
         self.returns(void)
 
-connect("saw-remote-api --dynamic4")
+connect("cabal -v0 v2-run exe:saw-remote-api")
 
 mod = llvm_load_module(swap_bc)
 

--- a/python/argo/connection.py
+++ b/python/argo/connection.py
@@ -6,7 +6,7 @@ import re
 import socket
 import subprocess
 import signal
-import sys # pylint: disable=unused-import
+import sys  # pylint: disable=unused-import
 from typing import Any, Dict, List, Mapping, Optional, Union
 from mypy_extensions import TypedDict
 
@@ -14,10 +14,10 @@ from . import netstring
 
 
 # Must be boxed separately to enable sharing of connections
-class IDSource: # pylint: disable=too-few-public-methods
+class IDSource:  # pylint: disable=too-few-public-methods
     """A source of unique identifiers for JSON RPC requests."""
 
-    next_id : int
+    next_id: int
 
     def __init__(self) -> None:
         self.next_id = 0
@@ -27,16 +27,19 @@ class IDSource: # pylint: disable=too-few-public-methods
         self.next_id += 1
         return self.next_id
 
+
 class ServerProcess:
     """A wrapper around a server process, responsible for setting it up and
        killing it when finished."""
 
-    proc : Optional[subprocess.Popen]
+    proc: Optional[subprocess.Popen]
 
-    def __init__(self, command : str) -> None:
+    def __init__(self, command: str) -> None:
         """Start the process using the given command.
 
-           :param command: The command to be executed, using a shell, to start the server."""
+           :param command: The command to be executed, using a shell, to start
+           the server.
+        """
         self.command = command
         self.proc = None
         self.setup()
@@ -54,7 +57,8 @@ class ServerProcess:
         """Start a process, if one is not already running, using the
            environment determined by ``get_environment``."""
         if self.proc is None or self.proc.poll() is not None:
-            # To debug, consider setting stderr to sys.stdout instead (to see server log messages).
+            # To debug, consider setting stderr to sys.stdout instead (to see
+            # server log messages).
             self.proc = subprocess.Popen(
                 self.command,
                 shell=True,
@@ -73,7 +77,7 @@ class ServerProcess:
             if match:
                 self.port = int(match.group(1))
             else:
-                raise Exception("Failed to load process, output was `" + \
+                raise Exception("Failed to load process, output was `" +
                                 out_line + "' but expected PORT then a port.")
 
     def __del__(self) -> None:
@@ -95,9 +99,9 @@ class ServerConnection:
        answer received (if any). Furthermore, it has a means of
        sending messages to the server.
     """
-    replies : Dict[int, Any]
+    replies: Dict[int, Any]
 
-    def __init__(self, process : ServerProcess) -> None:
+    def __init__(self, process: ServerProcess) -> None:
         """:param process: The ``ServerProcess`` used for the connection."""
         self.process = process
         self.port = self.process.port
@@ -149,14 +153,14 @@ class ServerConnection:
             self.replies[the_reply['id']] = the_reply
             reply_bytes = self._get_one_reply()
 
-    def send_message(self, method : str, params : dict) -> int:
+    def send_message(self, method: str, params: dict) -> int:
         """Send a message to the server with the given JSONRPC method and
            parameters. The return value is the unique request ID that
            was used for the message, which can be used to find
            replies.
         """
         request_id = self.get_id()
-        msg = {'jsonrpc':'2.0',
+        msg = {'jsonrpc': '2.0',
                'method': method,
                'id': request_id,
                'params': params}
@@ -165,14 +169,14 @@ class ServerConnection:
         self.sock.send(msg_bytes)
         return request_id
 
-    def wait_for_reply_to(self, request_id : int) -> Any:
+    def wait_for_reply_to(self, request_id: int) -> Any:
         """Block until a reply is received for the given
            ``request_id``. Return the reply."""
         self._process_replies()
         while request_id not in self.replies:
             try:
-                #self.sock.setblocking(True)
+                # self.sock.setblocking(True)
                 self._process_replies()
             finally:
                 self.sock.setblocking(False)
-        return self.replies.pop(request_id) # deletes reply whilst returning it
+        return self.replies.pop(request_id)  # delete reply whilst returning it

--- a/python/argo/connection.py
+++ b/python/argo/connection.py
@@ -102,8 +102,8 @@ class ServerConnection:
         self.process = process
         self.port = self.process.port
 
-        self.sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.sock.connect(("127.0.0.1", self.port))
+        self.sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+        self.sock.connect(("localhost", self.port))
         self.sock.setblocking(False)
         self.buf = bytearray(b'')
         self.replies = {}

--- a/python/argo/connection.py
+++ b/python/argo/connection.py
@@ -88,6 +88,13 @@ class ServerProcess:
         else:
             return None
 
+    def running(self) -> bool:
+        """Check whether the process is still running."""
+        if self.proc.poll() is None:
+            return True
+        else:
+            return False
+
     def __del__(self) -> None:
         if self.proc is not None:
             if not self.persist:

--- a/python/cryptol/__init__.py
+++ b/python/cryptol/__init__.py
@@ -22,7 +22,7 @@ __all__ = ['cryptoltypes']
 
 # Current status:
 #  It can currently launch a server, given a suitable command line as an argument. Try this:
-#  >>> c = CryptolConnection("cabal new-exec cryptol-remote-api -- --dynamic4")
+#  >>> c = CryptolConnection("cabal -v0 run cryptol-remote-api")
 #  >>> f = c.load_file(FILE)
 #  >>> f.result()
 #

--- a/python/saw/__init__.py
+++ b/python/saw/__init__.py
@@ -1,6 +1,6 @@
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass, field
-from typing import List, Optional, Set, Union, Dict, Tuple, Any
+from typing import List, Optional, Set, Union, Dict, Tuple, Any, Callable
 import webbrowser
 import subprocess
 import uuid
@@ -17,113 +17,34 @@ from argo.interaction import ArgoException
 from . import llvm
 from . import exceptions
 from . import proofscript
-from . import dashboard
 
-designated_connection = None      # type: Optional[connection.SAWConnection]
-designated_dashboard_path = None  # type: Optional[str]
+__designated_connection = None  # type: Optional[connection.SAWConnection]
+__designated_views = []         # type: List[View]
+__global_success = True         # type: bool
 
 # Script-execution-global set of all results verified so far
-all_verification_results = None  # type: Optional[AllVerificationResults]
-used_server_names = set([])      # type: Set[str]
+__used_server_names = set([])      # type: Set[str]
 
 
-def fresh_server_name(hint: Optional[str] = None) -> str:
+def __fresh_server_name(hint: Optional[str] = None) -> str:
     if hint is None:
         hint = 'x'
-    name = llvm.uniquify(hint, used_server_names)
-    used_server_names.add(name)
+    name = llvm.uniquify(hint, __used_server_names)
+    __used_server_names.add(name)
     return name
 
 
-def get_designated_connection() -> connection.SAWConnection:
-    global designated_connection
-    if designated_connection is None:
+def __get_designated_connection() -> connection.SAWConnection:
+    global __designated_connection
+    if __designated_connection is None:
         raise ValueError("There is not yet a designated connection.")
     else:
-        return designated_connection
+        return __designated_connection
 
 
-def get_designated_url() -> str:
-    global designated_dashboard_path
-    if designated_dashboard_path is None:
-        raise ValueError("There is not yet a designated dashboard URL")
-    else:
-        return "http://localhost:" + str(dashboard.DEFAULT_PORT) \
-            + "/" + designated_dashboard_path
-
-
-def set_designated_connection(conn: connection.SAWConnection) -> None:
-    global designated_connection
-    designated_connection = conn
-
-
-def connect(command_or_connection: Union[str, ServerConnection],
-            dashboard_path: Optional[str] = None,
-            *, persist=False) -> None:
-    global designated_connection
-    global designated_dashboard_path
-    global all_verification_results
-    if all_verification_results is None:
-        all_verification_results = AllVerificationResults()
-    else:
-        raise ValueError("There is already an initialized list of verification"
-                         " results. Did you call `connect()` more than once?")
-    atexit.register(qed)  # call qed before shutting down
-
-    # Set the designated connection by starting a server process
-    if designated_connection is None:
-        designated_connection = \
-            connection.SAWConnection(command_or_connection, persist=persist)
-    else:
-        raise ValueError("There is already a designated connection."
-                         " Did you call `connect()` more than once?")
-
-    # After the script quits, print the server PID
-    if persist:
-        pid = designated_connection.pid()
-        atexit.register(lambda: print(f"Persistent server process PID: {pid}"))
-
-    # Set up the dashboard path
-    if designated_dashboard_path is None:
-        if dashboard_path is None:
-            current_frame = inspect.currentframe()
-            if current_frame is None:
-                raise ValueError("Cannot automatically assign a dashboard URL"
-                                 " outside a file; use the explicit option"
-                                 " `dashboard_path = \"...\"` when calling "
-                                 "`connect()`")
-            else:
-                f_back = current_frame.f_back
-                if f_back is not None:
-                    filename = os.path.realpath(inspect.getfile(f_back))
-                    dashboard_path = \
-                        re.sub(r'\.py$', '',
-                               posixpath.join(*filename.split(os.path.sep))) \
-                          .replace('^/', '')
-        designated_dashboard_path = dashboard_path
-    else:
-        raise ValueError("There is already a designated dashboard URL."
-                         " Did you call `connect()` more than once?")
-
-    # Print the dashboard path
-    print("Dashboard:", get_designated_url(), file=sys.stderr)
-
-
-def cryptol_load_file(filename: str) -> None:
-    get_designated_connection().cryptol_load_file(filename)
-    return None
-
-
-@dataclass
-class LLVMModule:
-    bitcode_file: str
-    server_name: str
-
-
-def llvm_load_module(bitcode_file: str) -> LLVMModule:
-    name = fresh_server_name(bitcode_file)
-    get_designated_connection().llvm_load_module(name, bitcode_file).result()
-    return LLVMModule(bitcode_file, name)
+def __set_designated_connection(conn: connection.SAWConnection) -> None:
+    global __designated_connection
+    __designated_connection = conn
 
 
 class VerificationResult(metaclass=ABCMeta):
@@ -183,148 +104,113 @@ class AssumptionFailed(VerificationFailed):
                          exception)
 
 
-class AllVerificationResults:
-    __results: Dict[uuid.UUID, VerificationResult]
-    __qed_called: bool
-    __proceeding_normally: bool
+def connect(command_or_connection: Union[str, ServerConnection],
+            *, persist: bool = False) -> None:
+    global __designated_connection
 
-    def __init__(self) -> None:
-        self.__results = {}
-        self.__update_dashboard__()
-        self.__qed_called = False
-        self.__proceeding_normally = True
+    # Set the designated connection by starting a server process
+    if __designated_connection is None:
+        __designated_connection = \
+            connection.SAWConnection(command_or_connection, persist=persist)
+    else:
+        raise ValueError("There is already a designated connection."
+                         " Did you call `connect()` more than once?")
 
-    def __add_result__(self, result: VerificationResult) -> None:
-        self.__results[result._unique_id] = result
-        self.__update_dashboard__()
+    # After the script quits, print the server PID
+    if persist:
+        def print_if_still_running():
+            try:
+                pid = __designated_connection.pid()
+                if __designated_connection.running():
+                    message = f"Created persistent server process: PID {pid}"
+                    print(message)
+            except ProcessLookupError:
+                pass
+        atexit.register(print_if_still_running)
 
-    def dot_graph(self) -> str:
-        out = "digraph { \n"
-        for _, result in self.__results.items():
-            # Determine the node color
-            if result:
-                color = "green"
-                bgcolor = "lightgreen"
-            else:
-                color = "red"
-                bgcolor = "lightpink"
-            # Determine the node attributes
-            node_attrs: Dict[str, str] = {
-                'label': result.contract.__class__.__name__,
-                'color': color,
-                'bgcolor': bgcolor,
-                'fontname': "Courier",
-                'shape': 'rect',
-                'penwidth': '2',
-            }
-            # Render the attributes
-            node_attr_string = ""
-            for key, val in node_attrs.items():
-                node_attr_string += key + " = \"" + val + "\"; "
-            # Render this node line
-            out += '    "' + str(result._unique_id) \
-                + '" [' + node_attr_string.rstrip('; ') + "];\n"
-            # Render each of the assumption edges
-            for assumption in result.assumptions[:]:
-                edge_attrs: Dict[str, str] = {
-                    'penwidth': '2',
-                    'arrowType': 'open',
-                }
-                edge_attr_string = ""
-                for key, val in edge_attrs.items():
-                    edge_attr_string += key + " = \"" + val + "\"; "
-                out += '    "' \
-                    + str(assumption._unique_id) \
-                    + '" -> "' \
-                    + str(result._unique_id) \
-                    + '" [' + edge_attr_string.rstrip('; ') + '];\n'
-        out += "}"
-        # print(out)
-        return out
 
-    def svg_graph(self) -> str:
-        # Generate a GraphViz DOT representation
-        dot_repr = self.dot_graph()
-        # Write out & render the DOT file and open it in a web browser
-        svg = subprocess.check_output(["dot", "-T", "svg"],
-                                      input=dot_repr,
-                                      text=True)
-        return svg
+class View:
+    """An instance of View describes how to (potentially interactively) view
+       or log the results of a verification script, in real-time."""
 
-    def errors_html(self) -> str:
-        # Generate an HTML representation of all the errors so far
-        out = '<div style="padding: 20pt; '\
-            'font-family: Courier; text-align: left">'
-        if not self.all_ok():
-            out += '<h2>Errors:</h2>'
-        for _, result in self.__results.items():
-            if isinstance(result, VerificationFailed):
-                out += '<p style="font-size: 16pt">'
-                out += '<b>' + result.contract.__class__.__name__ + ': </b>'
-                out += '<span style="color: firebrick">'
-                out += str(result.exception)
-                out += '</span>'
-                out += '</p>'
-        out += '</div>'
-        return out
-
-    def dashboard_html(self) -> str:
-        progress: str
-        if self.__qed_called:
-            progress = '<span style="font-weight: normal">'
-            if self.all_ok():
-                progress += '✅ (successfully verified!)'
-            elif self.__proceeding_normally:
-                progress += '🚫 (failed to verify)'
-            else:
-                progress += '🚫 (incomplete: exception during proving)'
-            progress += '</span>'
-        else:
-            progress = '<i style="font-weight: normal">(running...)</i>'
-        if designated_dashboard_path is not None:
-            proof_name: str = os.path.basename(designated_dashboard_path)
-            return \
-                '<center><h1 style="font-family: Courier">' \
-                + proof_name + ': ' + progress \
-                + """</h1><div height="100%><svg height="100%" width="100%">""" \
-                + self.svg_graph() \
-                + "</svg></div>" \
-                + "<div>" \
-                + self.errors_html() \
-                + "</div></center>"
-        else:
-            raise ValueError("Can't render dashboard HTML before dashboard is initialized")
-
-    def __update_dashboard__(self) -> None:
+    def on_failure(self, failure: VerificationFailed) -> None:
+        """When a verification attempt fails, do this."""
         pass
-        # if designated_dashboard_path is not None:
-        #     dashboard.serve_self_refreshing(designated_dashboard_path,
-        #                                     os.path.basename(designated_dashboard_path),
-        #                                     self.dashboard_html(),
-        #                                     within_process=lambda: atexit.unregister(qed))
-        # else:
-        #     ValueError("Attempted to update dashboard before it was initialized")
 
-    def all_ok(self) -> bool:
-        # Iterate through all lemmata to determine if everything is okay
-        # Builds a graph of all dependencies
-        ok = True
-        for _, result in self.__results.items():
-            if not result:
-                ok = False
-        return ok
+    def on_success(self, success: VerificationSucceeded) -> None:
+        """When a verification attempt succeeds, do this."""
+        pass
 
-    def __qed__(self, complete: bool) -> None:
-        self.__qed_called = True
-        self.__proceeding_normally = \
-            self.__proceeding_normally and complete
-        self.__update_dashboard__()
-        if not self.all_ok():
-            print("Verification did not succeed.", file=sys.stderr)
-            sys.exit(1)
-        else:
-            print("Verification succeeded.", file=sys.stderr)
-            sys.exit(0)
+    def on_finish_success(self) -> None:
+        """After all verifications are finished successfully, do this."""
+        pass
+
+    def on_finish_failure(self) -> None:
+        """After all verifications are finished but with some failures,
+           do this."""
+        pass
+
+
+class LogResults(View):
+    """A view on the verification results that logs failures and successes in a
+       human-readable text format to stdout, or a given file handle."""
+
+    def __init__(self, file=sys.stdout):
+        self.file = file
+        self.all_ok = True
+
+    def __result_attributes(result):
+        lineno = result.contract.definition_lineno()
+        if lineno is None:
+            lineno = "<unknown line>"
+        filename = result.contract.definition_filename()
+        if filename is None:
+            filename = "<unknown file>"
+        lemma_name = result.contract.lemma_name()
+        return (filename, lineno, lemma_name)
+
+    def on_failure(self, result) -> None:
+        filename, lineno, lemma_name = LogResults.__result_attributes(result)
+        print(f"Failed to verify: {lemma_name}"
+              f" (defined at {filename}:{lineno}): {result.exception}",
+              file=self.file)
+
+    def on_success(self, result) -> None:
+        filename, lineno, lemma_name = LogResults.__result_attributes(result)
+        print(f"Verified: {lemma_name}"
+              f" (defined at {filename}:{lineno})",
+              file=self.file)
+
+    def on_finish_success(self) -> None:
+        print("All verified!", file=self.file)
+
+    def on_finish_failure(self) -> None:
+        print("Some lemmas failed to verify.", file=self.file)
+
+
+def view(v: View) -> None:
+    """Add a view to the global list of views. Future verification results will
+       be handed to this view, and its on_finish() handler will be called at
+       the end of the script."""
+    global __designated_views
+    __designated_views.append(v)
+
+
+def cryptol_load_file(filename: str) -> None:
+    __get_designated_connection().cryptol_load_file(filename)
+    return None
+
+
+@dataclass
+class LLVMModule:
+    bitcode_file: str
+    server_name: str
+
+
+def llvm_load_module(bitcode_file: str) -> LLVMModule:
+    name = __fresh_server_name(bitcode_file)
+    __get_designated_connection().llvm_load_module(name, bitcode_file).result()
+    return LLVMModule(bitcode_file, name)
 
 
 def llvm_verify(module: LLVMModule,
@@ -341,11 +227,11 @@ def llvm_verify(module: LLVMModule,
         script = proofscript.ProofScript([proofscript.abc])
 
     lemma_name_hint = contract.__class__.__name__ + "_" + function
-    name = llvm.uniquify(lemma_name_hint, used_server_names)
-    used_server_names.add(name)
+    name = llvm.uniquify(lemma_name_hint, __used_server_names)
+    __used_server_names.add(name)
 
     result: VerificationResult
-    conn = get_designated_connection()
+    conn = __get_designated_connection()
     conn_snapshot = conn.snapshot()
     abort_proof = False
     try:
@@ -363,8 +249,8 @@ def llvm_verify(module: LLVMModule,
     except exceptions.VerificationError as err:
         # roll back to snapshot because the current connection's
         # latest result is now a verification exception!
-        set_designated_connection(conn_snapshot)
-        conn = get_designated_connection()
+        __set_designated_connection(conn_snapshot)
+        conn = __get_designated_connection()
         # Assume the verification succeeded
         try:
             conn.llvm_assume(module.server_name,
@@ -377,30 +263,38 @@ def llvm_verify(module: LLVMModule,
                                         exception=err)
         # If something stopped us from even **assuming**...
         except exceptions.VerificationError as err:
-            set_designated_connection(conn_snapshot)
+            __set_designated_connection(conn_snapshot)
             result = AssumptionFailed(server_name=name,
                                       assumptions=lemmas,
                                       contract=contract,
                                       exception=err)
             abort_proof = True
 
-    # Add the verification result to the list
-    global all_verification_results
-    if all_verification_results is not None:
-        all_verification_results.__add_result__(result)
-    else:
-        raise ValueError("Could not track verification result because" \
-                         " connection is not yet initialized")
+    # Log or otherwise process the verification result
+    global __designated_views
+    for view in __designated_views:
+        if result:
+            view.on_success(result)
+        else:
+            view.on_failure(result)
 
     # Abort the proof if we failed to assume a failed verification, otherwise
     # return the result of the verification
     if abort_proof:
-        all_verification_results.__qed__(False)
+        sys.exit(1)
+
+    # Note when any failure occurs
+    global __global_success
+    __global_success = __global_success and result
+
     return result
 
 
 @atexit.register
-def qed() -> None:
-    global all_verification_results
-    if all_verification_results is not None:
-        all_verification_results.__qed__(True)
+def script_exit():
+    global __designated_views
+    for view in __designated_views:
+        if __global_success:
+            view.on_finish_success()
+        else:
+            view.on_finish_failure()

--- a/python/saw/connection.py
+++ b/python/saw/connection.py
@@ -8,8 +8,8 @@ from saw.commands import *
 from typing import Optional, Union, Any, List
 
 
-def connect(command: str, cryptol_path: Optional[str] = None) -> SAWConnection:
-    return SAWConnection(command)
+def connect(command: str, cryptol_path: Optional[str] = None, *, persist=False) -> SAWConnection:
+    return SAWConnection(command, persist=persist)
 
 
 class SAWConnection:
@@ -17,13 +17,20 @@ class SAWConnection:
 
     most_recent_result: Optional[argo.interaction.Interaction]
 
-    def __init__(self, command_or_connection: Union[str, ac.ServerConnection]) -> None:
+    def __init__(self,
+                 command_or_connection: Union[str, ac.ServerConnection],
+                 *, persist=False) -> None:
         self.most_recent_result = None
+        self.persist = persist
         if isinstance(command_or_connection, str):
-            self.proc = ac.ServerProcess(command_or_connection)
+            self.proc = ac.ServerProcess(command_or_connection, persist=self.persist)
             self.server_connection = ac.ServerConnection(self.proc)
         else:
             self.server_connection = command_or_connection
+
+    def pid(self) -> int:
+        """Return the PID of the running server process."""
+        return self.proc.pid()
 
     def snapshot(self) -> SAWConnection:
         """Return a ``SAWConnection`` that has the same process and state as

--- a/python/saw/connection.py
+++ b/python/saw/connection.py
@@ -32,6 +32,10 @@ class SAWConnection:
         """Return the PID of the running server process."""
         return self.proc.pid()
 
+    def running(self) -> bool:
+        """Return whether the underlying server process is still running."""
+        return self.proc.running()
+
     def snapshot(self) -> SAWConnection:
         """Return a ``SAWConnection`` that has the same process and state as
         the current connection. The new connection's state will be

--- a/python/saw/connection.py
+++ b/python/saw/connection.py
@@ -7,15 +7,17 @@ from saw.commands import *
 
 from typing import Optional, Union, Any, List
 
-def connect(command : str, cryptol_path : Optional[str] = None) -> SAWConnection:
+
+def connect(command: str, cryptol_path: Optional[str] = None) -> SAWConnection:
     return SAWConnection(command)
+
 
 class SAWConnection:
     """A representation of a current user state in a session with SAW."""
 
-    most_recent_result : Optional[argo.interaction.Interaction]
+    most_recent_result: Optional[argo.interaction.Interaction]
 
-    def __init__(self, command_or_connection : Union[str, ac.ServerConnection]) -> None:
+    def __init__(self, command_or_connection: Union[str, ac.ServerConnection]) -> None:
         self.most_recent_result = None
         if isinstance(command_or_connection, str):
             self.proc = ac.ServerProcess(command_or_connection)
@@ -39,29 +41,31 @@ class SAWConnection:
             return self.most_recent_result.state()
 
     # Protocol messages
-    def cryptol_load_file(self, filename : str) -> argo.interaction.Command:
+    def cryptol_load_file(self, filename: str) -> argo.interaction.Command:
         self.most_recent_result = CryptolLoadFile(self, filename)
         return self.most_recent_result
 
-    def llvm_load_module(self, name : str, bitcode_file : str)  -> argo.interaction.Command:
+    def llvm_load_module(self, name: str, bitcode_file: str)  -> argo.interaction.Command:
         self.most_recent_result = LLVMLoadModule(self, name, bitcode_file)
         return self.most_recent_result
 
     def llvm_verify(self,
-                    module : str,
-                    function : str,
-                    lemmas : List[str],
-                    check_sat : bool,
-                    contract : Any,
-                    script : Any,
-                    lemma_name : str) -> argo.interaction.Command:
-        self.most_recent_result = LLVMVerify(self, module, function, lemmas, check_sat, contract, script, lemma_name)
+                    module: str,
+                    function: str,
+                    lemmas: List[str],
+                    check_sat: bool,
+                    contract: Any,
+                    script: Any,
+                    lemma_name: str) -> argo.interaction.Command:
+        self.most_recent_result = \
+            LLVMVerify(self, module, function, lemmas, check_sat, contract, script, lemma_name)
         return self.most_recent_result
 
     def llvm_assume(self,
-                    module : str,
-                    function : str,
-                    contract : Any,
-                    lemma_name : str) -> argo.interaction.Command:
-        self.most_recent_result = LLVMAssume(self, module, function, contract, lemma_name)
+                    module: str,
+                    function: str,
+                    contract: Any,
+                    lemma_name: str) -> argo.interaction.Command:
+        self.most_recent_result = \
+            LLVMAssume(self, module, function, contract, lemma_name)
         return self.most_recent_result

--- a/python/saw/dashboard.py
+++ b/python/saw/dashboard.py
@@ -37,7 +37,10 @@ def serve_self_refreshing(path: str, title: str, content: str) -> None:
     url = 'http://localhost:' + str(MYXINE_PORT) + '/' + path.strip('/')
     wrapped_content = '<div id="content">' + content + '</div>'
     requests.post(url=url,
-                  params={'title': title},
+                  params={
+                      'title': title,
+                      'refresh': 'set',
+                  },
                   data=wrapped_content.encode("utf-8"))
 
 
@@ -122,7 +125,15 @@ class Dashboard(View):
         svg = subprocess.check_output(["dot", "-T", "svg"],
                                       input=dot_repr,
                                       text=True)
-        return svg
+        cleaned = []
+        lines = svg.split('\n').__iter__()
+        for line in lines:
+            if line.startswith('<svg'):
+                cleaned.append(line)
+                break
+        for line in lines:
+            cleaned.append(line)
+        return '\n'.join(cleaned)
 
     def errors_html(self) -> str:
         # Generate an HTML representation of all the errors so far
@@ -168,7 +179,7 @@ class Dashboard(View):
         return \
             '<center><h1 style="font-family: Courier">' \
             + proof_name \
-            + """</h1><div height="100%>""" \
+            + """</h1><div height="100%">""" \
             + self.svg_graph() \
             + "</div>" \
             + "<div>" \

--- a/python/saw/dashboard.py
+++ b/python/saw/dashboard.py
@@ -9,28 +9,28 @@ from . import View, VerificationResult, VerificationFailed
 MYXINE_PORT = 1123
 
 # Loading SVG is licensed for free reuse from https://icons8.com/preloaders/
-LOADING_SVG = '' # \
-    # """<svg xmlns:svg="http://www.w3.org/2000/svg"
-    # xmlns="http://www.w3.org/2000/svg"
-    # xmlns:xlink="http://www.w3.org/1999/xlink"
-    # version="1.0" width="35pt" height="35pt" viewBox="0 0 128 128"
-    # xml:space="preserve">
-    # <g><path d="M59.6 0h8v40h-8V0z" fill="#000"/>
-    # <path d="M59.6 0h8v40h-8V0z" fill="#ccc" transform="rotate(30 64 64)"/>
-    # <path d="M59.6 0h8v40h-8V0z" fill="#ccc" transform="rotate(60 64 64)"/>
-    # <path d="M59.6 0h8v40h-8V0z" fill="#ccc" transform="rotate(90 64 64)"/>
-    # <path d="M59.6 0h8v40h-8V0z" fill="#ccc" transform="rotate(120 64 64)"/>
-    # <path d="M59.6 0h8v40h-8V0z" fill="#b2b2b2" transform="rotate(150 64 64)"/>
-    # <path d="M59.6 0h8v40h-8V0z" fill="#999" transform="rotate(180 64 64)"/>
-    # <path d="M59.6 0h8v40h-8V0z" fill="#7f7f7f" transform="rotate(210 64 64)"/>
-    # <path d="M59.6 0h8v40h-8V0z" fill="#666" transform="rotate(240 64 64)"/>
-    # <path d="M59.6 0h8v40h-8V0z" fill="#4c4c4c" transform="rotate(270 64 64)"/>
-    # <path d="M59.6 0h8v40h-8V0z" fill="#333" transform="rotate(300 64 64)"/>
-    # <path d="M59.6 0h8v40h-8V0z" fill="#191919" transform="rotate(330 64 64)"/>
-    # <animateTransform attributeName="transform" type="rotate"
-    # values="0 64 64;30 64 64;60 64 64;90 64 64;120 64 64;150 64 64;180 64 64;210 64 64;240 64 64;270 64 64;300 64 64;330 64 64"
-    # calcMode="discrete" dur="1320ms" repeatCount="indefinite">
-    # </animateTransform></g></svg>"""
+LOADING_SVG = \
+    """<svg xmlns:svg="http://www.w3.org/2000/svg"
+    xmlns="http://www.w3.org/2000/svg"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    version="1.0" width="35pt" height="35pt" viewBox="0 0 128 128"
+    xml:space="preserve">
+    <g><path d="M59.6 0h8v40h-8V0z" fill="#000"/>
+    <path d="M59.6 0h8v40h-8V0z" fill="#ccc" transform="rotate(30 64 64)"/>
+    <path d="M59.6 0h8v40h-8V0z" fill="#ccc" transform="rotate(60 64 64)"/>
+    <path d="M59.6 0h8v40h-8V0z" fill="#ccc" transform="rotate(90 64 64)"/>
+    <path d="M59.6 0h8v40h-8V0z" fill="#ccc" transform="rotate(120 64 64)"/>
+    <path d="M59.6 0h8v40h-8V0z" fill="#b2b2b2" transform="rotate(150 64 64)"/>
+    <path d="M59.6 0h8v40h-8V0z" fill="#999" transform="rotate(180 64 64)"/>
+    <path d="M59.6 0h8v40h-8V0z" fill="#7f7f7f" transform="rotate(210 64 64)"/>
+    <path d="M59.6 0h8v40h-8V0z" fill="#666" transform="rotate(240 64 64)"/>
+    <path d="M59.6 0h8v40h-8V0z" fill="#4c4c4c" transform="rotate(270 64 64)"/>
+    <path d="M59.6 0h8v40h-8V0z" fill="#333" transform="rotate(300 64 64)"/>
+    <path d="M59.6 0h8v40h-8V0z" fill="#191919" transform="rotate(330 64 64)"/>
+    <animateTransform attributeName="transform" type="rotate"
+    values="0 64 64;30 64 64;60 64 64;90 64 64;120 64 64;150 64 64;180 64 64;210 64 64;240 64 64;270 64 64;300 64 64;330 64 64"
+    calcMode="discrete" dur="1320ms" repeatCount="indefinite">
+    </animateTransform></g></svg>"""
 
 
 def serve_self_refreshing(path: str, title: str, content: str) -> None:

--- a/python/saw/dashboard.py
+++ b/python/saw/dashboard.py
@@ -9,39 +9,38 @@ from . import View, VerificationResult, VerificationFailed
 MYXINE_PORT = 1123
 
 # Loading SVG is licensed for free reuse from https://icons8.com/preloaders/
-LOADING_SVG = \
-    """<svg xmlns:svg="http://www.w3.org/2000/svg"
-    xmlns="http://www.w3.org/2000/svg"
-    xmlns:xlink="http://www.w3.org/1999/xlink"
-    version="1.0" width="35pt" height="35pt" viewBox="0 0 128 128"
-    xml:space="preserve">
-    <g><path d="M59.6 0h8v40h-8V0z" fill="#000"/>
-    <path d="M59.6 0h8v40h-8V0z" fill="#ccc" transform="rotate(30 64 64)"/>
-    <path d="M59.6 0h8v40h-8V0z" fill="#ccc" transform="rotate(60 64 64)"/>
-    <path d="M59.6 0h8v40h-8V0z" fill="#ccc" transform="rotate(90 64 64)"/>
-    <path d="M59.6 0h8v40h-8V0z" fill="#ccc" transform="rotate(120 64 64)"/>
-    <path d="M59.6 0h8v40h-8V0z" fill="#b2b2b2" transform="rotate(150 64 64)"/>
-    <path d="M59.6 0h8v40h-8V0z" fill="#999" transform="rotate(180 64 64)"/>
-    <path d="M59.6 0h8v40h-8V0z" fill="#7f7f7f" transform="rotate(210 64 64)"/>
-    <path d="M59.6 0h8v40h-8V0z" fill="#666" transform="rotate(240 64 64)"/>
-    <path d="M59.6 0h8v40h-8V0z" fill="#4c4c4c" transform="rotate(270 64 64)"/>
-    <path d="M59.6 0h8v40h-8V0z" fill="#333" transform="rotate(300 64 64)"/>
-    <path d="M59.6 0h8v40h-8V0z" fill="#191919" transform="rotate(330 64 64)"/>
-    <animateTransform attributeName="transform" type="rotate"
-    values="0 64 64;30 64 64;60 64 64;90 64 64;120 64 64;150 64 64;180 64 64;210 64 64;240 64 64;270 64 64;300 64 64;330 64 64"
-    calcMode="discrete" dur="1320ms" repeatCount="indefinite">
-    </animateTransform></g></svg>"""
+LOADING_SVG = '' # \
+    # """<svg xmlns:svg="http://www.w3.org/2000/svg"
+    # xmlns="http://www.w3.org/2000/svg"
+    # xmlns:xlink="http://www.w3.org/1999/xlink"
+    # version="1.0" width="35pt" height="35pt" viewBox="0 0 128 128"
+    # xml:space="preserve">
+    # <g><path d="M59.6 0h8v40h-8V0z" fill="#000"/>
+    # <path d="M59.6 0h8v40h-8V0z" fill="#ccc" transform="rotate(30 64 64)"/>
+    # <path d="M59.6 0h8v40h-8V0z" fill="#ccc" transform="rotate(60 64 64)"/>
+    # <path d="M59.6 0h8v40h-8V0z" fill="#ccc" transform="rotate(90 64 64)"/>
+    # <path d="M59.6 0h8v40h-8V0z" fill="#ccc" transform="rotate(120 64 64)"/>
+    # <path d="M59.6 0h8v40h-8V0z" fill="#b2b2b2" transform="rotate(150 64 64)"/>
+    # <path d="M59.6 0h8v40h-8V0z" fill="#999" transform="rotate(180 64 64)"/>
+    # <path d="M59.6 0h8v40h-8V0z" fill="#7f7f7f" transform="rotate(210 64 64)"/>
+    # <path d="M59.6 0h8v40h-8V0z" fill="#666" transform="rotate(240 64 64)"/>
+    # <path d="M59.6 0h8v40h-8V0z" fill="#4c4c4c" transform="rotate(270 64 64)"/>
+    # <path d="M59.6 0h8v40h-8V0z" fill="#333" transform="rotate(300 64 64)"/>
+    # <path d="M59.6 0h8v40h-8V0z" fill="#191919" transform="rotate(330 64 64)"/>
+    # <animateTransform attributeName="transform" type="rotate"
+    # values="0 64 64;30 64 64;60 64 64;90 64 64;120 64 64;150 64 64;180 64 64;210 64 64;240 64 64;270 64 64;300 64 64;330 64 64"
+    # calcMode="discrete" dur="1320ms" repeatCount="indefinite">
+    # </animateTransform></g></svg>"""
 
 
 def serve_self_refreshing(path: str, title: str, content: str) -> None:
     url = 'http://localhost:' + str(MYXINE_PORT) + '/' + path.strip('/')
-    wrapped_content = '<div id="content">' + content + '</div>'
     requests.post(url=url,
                   params={
                       'title': title,
-                      'refresh': 'set',
+                      # 'refresh': 'set',
                   },
-                  data=wrapped_content.encode("utf-8"))
+                  data=content.encode("utf-8"))
 
 
 class Dashboard(View):
@@ -132,7 +131,8 @@ class Dashboard(View):
                 cleaned.append(line)
                 break
         for line in lines:
-            cleaned.append(line)
+            if not line.startswith('<!--'):
+                cleaned.append(line)
         return '\n'.join(cleaned)
 
     def errors_html(self) -> str:
@@ -169,7 +169,6 @@ class Dashboard(View):
                 progress += \
                     '🚫 <span style="font-size: 25pt">' \
                     '(incomplete: exception during proving)</span>'
-            progress += '</div>'
         else:
             progress += LOADING_SVG \
                 + '<br/><span style="font-size: 25pt">' \

--- a/python/saw/llvm.py
+++ b/python/saw/llvm.py
@@ -337,6 +337,12 @@ class Contract:
 
         return name
 
+    def definition_lineno(self) -> Optional[int]:
+        return self.__definition_lineno
+
+    def definition_filename(self) -> Optional[str]:
+        return self.__definition_filename
+
     def to_json(self) -> Any:
         if self.__cached_json is not None:
             return self.__cached_json

--- a/saw-remote-api/test-scripts/assume.py
+++ b/saw-remote-api/test-scripts/assume.py
@@ -5,7 +5,7 @@ from saw.proofscript import *
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
-c = saw.connect("cabal new-exec --verbose=0 saw-remote-api -- --dynamic4")
+c = saw.connect("cabal new-exec --verbose=0 saw-remote-api")
 
 assume_bc = os.path.join(dir_path, 'assume.bc')
 

--- a/saw-remote-api/test-scripts/salsa20.py
+++ b/saw-remote-api/test-scripts/salsa20.py
@@ -8,7 +8,7 @@ from saw.proofscript import *
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
 print("Starting server")
-c = saw.connect("cabal new-exec --verbose=0 saw-remote-api -- --dynamic4")
+c = saw.connect("cabal new-exec --verbose=0 saw-remote-api")
 
 bcname = os.path.join(dir_path, 'salsa20.bc')
 cryname = os.path.join(dir_path, 'Salsa20.cry')

--- a/saw-remote-api/test-scripts/salsa20_easy.py
+++ b/saw-remote-api/test-scripts/salsa20_easy.py
@@ -5,7 +5,9 @@ from saw import *
 from saw.llvm import Contract, LLVMArrayType, uint8_t, uint32_t, void
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
+
 connect("cabal new-exec --verbose=0 saw-remote-api")
+view(LogResults())
 
 bcname = os.path.join(dir_path, 'salsa20.bc')
 cryname = os.path.join(dir_path, 'Salsa20.cry')
@@ -27,7 +29,6 @@ class RotlContract(Contract):
 
 
 rotl_result = llvm_verify(mod, 'rotl', RotlContract())
-print(rotl_result)
 
 class TrivialContract(Contract):
     def post(self): self.returns(void)
@@ -69,7 +70,6 @@ class QuarterRoundContract(Contract):
 
 
 qr_result = llvm_verify(mod, 's20_quarterround', QuarterRoundContract(), lemmas=[rotl_result])
-print(qr_result)
 
 
 class OnePointerUpdateContract(Contract):
@@ -100,7 +100,6 @@ class RowRoundContract(OnePointerUpdateContract):
         self.points_to(self.y_p, self.cryptol("rowround")(self.y))
 
 rr_result = llvm_verify(mod, 's20_rowround', RowRoundContract(), lemmas=[qr_result])
-print(rr_result)
 
 
 class ColumnRoundContract(OnePointerUpdateContract):
@@ -112,7 +111,6 @@ class ColumnRoundContract(OnePointerUpdateContract):
         self.points_to(self.y_p, self.cryptol("columnround")(self.y))
 
 cr_result = llvm_verify(mod, 's20_columnround', ColumnRoundContract(), lemmas=[rr_result])
-print(cr_result)
 
 
 class DoubleRoundContract(OnePointerUpdateContract):
@@ -124,7 +122,6 @@ class DoubleRoundContract(OnePointerUpdateContract):
         self.points_to(self.y_p, self.cryptol("doubleround")(self.y))
 
 dr_result = llvm_verify(mod, 's20_doubleround', DoubleRoundContract(), lemmas=[cr_result, rr_result])
-print(dr_result)
 
 
 class HashContract(OnePointerUpdateContract):
@@ -136,7 +133,6 @@ class HashContract(OnePointerUpdateContract):
         self.points_to(self.y_p, self.cryptol("Salsa20")(self.y))
 
 hash_result = llvm_verify(mod, 's20_hash', HashContract(), lemmas=[dr_result])
-print(hash_result)
 
 
 class ExpandContract(Contract):
@@ -159,7 +155,6 @@ class ExpandContract(Contract):
         self.points_to(self.ks_p, self.cryptol("Salsa20_expansion`{a=2}")((self.k, self.n)))
 
 expand_result = llvm_verify(mod, 's20_expand32', ExpandContract(), lemmas=[hash_result])
-print(expand_result)
 
 
 class Salsa20CryptContract(Contract):
@@ -187,4 +182,3 @@ class Salsa20CryptContract(Contract):
         self.points_to(self.m_p, self.cryptol("Salsa20_encrypt")((self.k, self.v, self.m)))
 
 crypt_result = llvm_verify(mod, 's20_crypt32', Salsa20CryptContract(63), lemmas=[expand_result])
-print(crypt_result)

--- a/saw-remote-api/test-scripts/salsa20_easy.py
+++ b/saw-remote-api/test-scripts/salsa20_easy.py
@@ -5,7 +5,7 @@ from saw import *
 from saw.llvm import Contract, LLVMArrayType, uint8_t, uint32_t, void
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
-connect("cabal new-exec --verbose=0 saw-remote-api -- --dynamic4")
+connect("cabal new-exec --verbose=0 saw-remote-api")
 
 bcname = os.path.join(dir_path, 'salsa20.bc')
 cryname = os.path.join(dir_path, 'Salsa20.cry')

--- a/saw-remote-api/test-scripts/saw-test.py
+++ b/saw-remote-api/test-scripts/saw-test.py
@@ -10,7 +10,7 @@ dir_path = os.path.dirname(os.path.realpath(__file__))
 
 print("This is " + dir_path)
 
-c = saw.connect("cabal new-exec --verbose=0 saw-remote-api -- --dynamic4")
+c = saw.connect("cabal new-exec --verbose=0 saw-remote-api")
 
 cry_file = os.path.join(dir_path, 'Foo.cry')
 c.cryptol_load_file(cry_file)

--- a/saw-remote-api/test-scripts/seven.py
+++ b/saw-remote-api/test-scripts/seven.py
@@ -5,7 +5,7 @@ from saw.proofscript import *
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
-c = saw.connect("cabal new-exec --verbose=0 saw-remote-api -- --dynamic4")
+c = saw.connect("cabal new-exec --verbose=0 saw-remote-api")
 
 seven_bc = os.path.join(dir_path, 'seven.bc')
 

--- a/saw-remote-api/test-scripts/swap.py
+++ b/saw-remote-api/test-scripts/swap.py
@@ -5,7 +5,7 @@ from saw.proofscript import *
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
-c = saw.connect("cabal new-exec --verbose=0 saw-remote-api -- --dynamic4")
+c = saw.connect("cabal new-exec --verbose=0 saw-remote-api")
 
 swap_bc = os.path.join(dir_path, 'swap.bc')
 

--- a/saw-remote-api/test-scripts/swap_easy.py
+++ b/saw-remote-api/test-scripts/swap_easy.py
@@ -28,7 +28,7 @@ class Swap(Contract):
         self.points_to(self.y_pointer, self.x)
         self.returns(void)
 
-connect("cabal new-exec --verbose=0 saw-remote-api -- --dynamic4")
+connect("cabal new-exec --verbose=0 saw-remote-api")
 
 mod = llvm_load_module(swap_bc)
 

--- a/saw-remote-api/test-scripts/swap_fancy.py
+++ b/saw-remote-api/test-scripts/swap_fancy.py
@@ -6,7 +6,7 @@ from saw.proofscript import *
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
-c = saw.connect("cabal new-exec --verbose=0 saw-remote-api -- --dynamic4")
+c = saw.connect("cabal new-exec --verbose=0 saw-remote-api")
 
 swap_bc = os.path.join(dir_path, 'swap.bc')
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.7
+resolver: lts-14.27
 
 packages:
 - argo


### PR DESCRIPTION
This PR implements persistence of the server process, with the ability to name a given session so that future invocations of the server pointed at the same session name will report the port for that session rather than instantiating a new server process. (That is, fixes #35.)

Now, having been merged with a branch for detangling the dashboard code, this PR also fixes #58.

Items included in this PR:

- [x] the Argo library now supports a `--session` argument to specify a named session to create or look up (atomicity enforced using file locks)
- [x] docs need to be updated, since the command line interface has changed
- [x] cleanup of the temp directory tracking sessions needs to happen, or else there will be a (albeit glacially slow) filesystem space leak
- [x] double-check that there are no outlying examples outside the test suite that invoke the old command line flags
- [x] change Python library to use a default overrideable session name, and alter its process management so that the server process outlives the Python script