### PR TITLE
Modify Argo protocol and Python SAW client to track stdout/err

### DIFF
--- a/argo/src/Argo.hs
+++ b/argo/src/Argo.hs
@@ -9,6 +9,8 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE RankNTypes #-}
 {-# OPTIONS_GHC -Wno-redundant-constraints -Wno-name-shadowing #-}
 
 -- | An implementation of the basic primitives of JSON-RPC 2.0.
@@ -184,6 +186,10 @@ data JSONRPCException =
     , errorID :: Maybe RequestID
       -- ^ The request ID, if one is available. @Nothing@ omits
       -- it, because JSON-RPC defines a meaning for null.
+    , errorStdOut :: String
+      -- ^ The standard output of the method producing this error
+    , errorStdErr :: String
+      -- ^ The standard error of the method producing this error
     } deriving Show
 
 instance Exception JSONRPCException
@@ -198,8 +204,12 @@ instance JSON.ToJSON JSONRPCException where
           Just theID -> JSON.toJSON theID
       , "error" .=
         (JSON.object $ ["code" .= JSON.Number (fromInteger (errorCode exn))
-                       , "message" .= JSON.String (message exn)] ++
-                       (("data" .=) <$> maybeToList (errorData exn)))
+                      , "message" .= JSON.String (message exn)
+                      , "data" .= (JSON.object $
+                        ([ "stdout" .= errorStdOut exn
+                         , "stderr" .= errorStdErr exn ] ++
+                         (("data" .=) <$> maybeToList (errorData exn))))
+                      ])
       ]
 
 -- | A method was provided with incorrect parameters (from the JSON-RPC spec)
@@ -209,6 +219,8 @@ invalidParams msg params =
                    , message = T.pack ("Invalid params: " ++ msg)
                    , errorData = Just params
                    , errorID = Nothing
+                   , errorStdOut = ""
+                   , errorStdErr = ""
                    }
 
 -- | The input string could not be parsed as JSON (from the JSON-RPC spec)
@@ -218,6 +230,8 @@ parseError msg =
                    , message   = "Parse error"
                    , errorData = Just (JSON.String msg)
                    , errorID   = Nothing
+                   , errorStdOut = ""
+                   , errorStdErr = ""
                    }
 
 -- | The method called does not exist (from the JSON-RPC spec)
@@ -227,6 +241,8 @@ methodNotFound meth =
                    , message   = "Method not found"
                    , errorData = Just (JSON.toJSON meth)
                    , errorID   = Nothing
+                   , errorStdOut = ""
+                   , errorStdErr = ""
                    }
 
 -- | The request issued is not valid (from the JSON-RPC spec)
@@ -236,6 +252,8 @@ invalidRequest =
                    , message   = "Invalid request"
                    , errorData = Nothing
                    , errorID   = Nothing
+                   , errorStdOut = ""
+                   , errorStdErr = ""
                    }
 
 -- | Some unspecified bad thing happened in the server (from the JSON-RPC spec)
@@ -245,6 +263,8 @@ internalError =
                    , message   = "Internal error"
                    , errorData = Nothing
                    , errorID   = Nothing
+                   , errorStdOut = ""
+                   , errorStdErr = ""
                    }
 
 -- | Construct a 'JSONRPCException' from an error code, error text, and perhaps
@@ -256,6 +276,8 @@ makeJSONRPCException c m d =
     , message = m
     , errorData = JSON.toJSON <$> d
     , errorID = Nothing
+    , errorStdOut = ""
+    , errorStdErr = ""
     }
 
 {-
@@ -339,6 +361,83 @@ instance JSON.ToJSON Request where
       "id"      .= view requestID     req <>
       "params"  .= view requestParams req
 
+data Response a
+  = Response { _responseID :: RequestID
+             , _responseAnswer :: a
+             , _responseStdOut :: String
+             , _responseStdErr :: String
+             } deriving (Eq, Ord, Show)
+
+responseID :: Simple Lens (Response a) RequestID
+responseID = lens _responseID (\r m -> r { _responseID = m })
+
+responseAnswer :: Simple Lens (Response a) a
+responseAnswer = lens _responseAnswer (\r m -> r { _responseAnswer = m })
+
+responseStdOut :: Simple Lens (Response a) String
+responseStdOut = lens _responseStdOut (\r m -> r { _responseStdOut = m })
+
+responseStdErr :: Simple Lens (Response a) String
+responseStdErr = lens _responseStdOut (\r m -> r { _responseStdOut = m })
+
+instance JSON.FromJSON a => JSON.FromJSON (Response a) where
+  parseJSON =
+    JSON.withObject ("JSON-RPC" <> T.unpack jsonRPCVersion <> " request") $
+    \o ->
+      (o .: "jsonrpc" `suchThat` (== jsonRPCVersion)) *>
+      (do result <- o .: "result"
+          Response
+            <$> o .: "id"
+            <*> result .: "answer"
+            <*> result .: "stdout"
+            <*> result .: "stderr")
+
+instance JSON.ToJSON a => JSON.ToJSON (Response a) where
+  toJSON resp =
+    JSON.object
+      [ "jsonrpc" .= jsonRPCVersion
+      , "id"      .= view responseID resp
+      , "result"  .= JSON.object
+        [ "answer"  .= view responseAnswer resp
+        , "stdout"  .= view responseStdOut resp
+        , "stderr"  .= view responseStdErr resp ] ]
+
+runMethodResponse ::
+  Method s a -> RequestID -> (Text -> IO ()) -> s -> IO (s, Response a)
+execMethodSilently ::
+  Method s a -> (Text -> IO ()) -> s -> IO s
+(runMethodResponse, execMethodSilently) =
+  ( \m reqID logger st ->
+      tryOutErr hCapture reqID (runMethod m logger st)
+  , \m logger st -> fst <$>
+      tryOutErr
+        (\hs a -> ("",) <$> hSilence hs a)
+        IDNull
+        (runMethod m logger st) )
+  where
+    tryOutErr ::
+      (forall a. [Handle] -> IO a -> IO (String, a)) ->
+      RequestID ->
+      IO (s, a) ->
+      IO (s, Response a)
+    tryOutErr capturer reqID action =
+      do (err, (out, res)) <-
+           capturer [stderr] . capturer [stdout] $
+           try @SomeException (try @JSONRPCException action)
+         tryPutOutErr out err
+         either
+           (\e -> let message = Just (JSON.String (T.pack (displayException e)))
+                  in throwIO $ internalError { errorData = message })
+           (either
+              (\e -> throwIO $ e { errorStdOut = out, errorStdErr = err })
+              (\(st, answer) -> pure (st, Response reqID answer out err)))
+           res
+      where
+        tryPutOutErr :: String -> String -> IO ()
+        tryPutOutErr out err =
+          do void $ try @IOException (hPutStr stdout out)
+             void $ try @IOException (hPutStr stderr err)
+
 handleRequest ::
   forall s.
   (Text -> IO ()) ->
@@ -347,37 +446,32 @@ handleRequest ::
   Request ->
   IO ()
 handleRequest logger respond app req =
-  tryOutErr $ case M.lookup method $ view appMethods app of
+  case M.lookup method $ view appMethods app of
     Nothing -> throwIO $ (methodNotFound method) { errorID = reqID }
     Just (Command, m) ->
-      withRequestID $
-      do answer <- modifyMVar theState $ runMethod (m params) logger
-         let response = JSON.object [ "jsonrpc" .= jsonRPCVersion
-                                    , "id" .= reqID
-                                    , "result" .= answer
-                                    ]
+      withRequestID $ \reqID ->
+      do response <- modifyMVar theState $
+           runMethodResponse (m params) reqID logger
          respond (JSON.encode response)
     Just (Query, m) ->
-      withRequestID $
-      do (_, answer) <- runMethod (m params) logger =<< readMVar theState
-         let response = JSON.object [ "jsonrpc" .= jsonRPCVersion
-                                    , "id" .= reqID
-                                    , "result" .= answer
-                                    ]
+      withRequestID $ \reqID ->
+      do (_, response) <-
+           runMethodResponse (m params) reqID logger =<< readMVar theState
          respond (JSON.encode response)
     Just (Notification, m) ->
       withoutRequestID $
-      void $ modifyMVar theState $ runMethod (m params) logger
+      modifyMVar theState $
+        \s -> (,()) <$> execMethodSilently (m params) logger s
   where
     method   = view requestMethod req
     params   = view requestParams req
     reqID    = view requestID req
     theState = view appState app
 
-    withRequestID :: IO a -> IO a
+    withRequestID :: (RequestID -> IO a) -> IO a
     withRequestID act =
       do rid <- requireID
-         catch act $ \e -> throwIO (e { errorID = Just rid })
+         catch (act rid) $ \e -> throwIO (e { errorID = Just rid })
 
     withoutRequestID :: IO a -> IO a
     withoutRequestID act =
@@ -386,18 +480,6 @@ handleRequest logger respond app req =
 
     requireID   = maybe (throwIO invalidRequest) return reqID
     requireNoID = maybe (return ()) (const (throwIO invalidRequest)) reqID
-
-    tryOutErr :: IO a -> IO a
-    tryOutErr action =
-      do (err, (out, res)) <- hCapture [stderr] . hCapture [stdout] $
-           try @SomeException action
-         tryPutOutErr out err
-         either throwIO pure res
-      where
-        tryPutOutErr :: String -> String -> IO ()
-        tryPutOutErr out err =
-          do void $ try @IOException (hPutStr stdout out)
-             void $ try @IOException (hPutStr stderr err)
 
 
 -- | Given an IO action, return an atomic-ified version of that same action,
@@ -502,7 +584,11 @@ serveHandlesNS hLog hIn hOut app =
 
     reportOtherException :: (BS.ByteString -> IO ()) -> SomeException -> IO ()
     reportOtherException out exn =
-      out $ JSON.encode (internalError { errorData = Just (JSON.String (T.pack (show exn))) })
+      out $ JSON.encode $
+      internalError { errorData = Just (JSON.String (T.pack (show exn)))
+                    , errorStdOut = "<no stdout captured: exception outside capture region>"
+                    , errorStdErr = "<no stderr captured: exception outside capture region>"
+                    }
 
     log :: Text -> IO ()
     log msg = case hLog of

--- a/examples/salsa20.py
+++ b/examples/salsa20.py
@@ -4,12 +4,13 @@ import os.path
 from cryptol.cryptoltypes import to_cryptol
 from saw.llvm import Contract, LLVMArrayType, uint8_t, uint32_t, void
 from saw import *
-from saw import dashboard
+from saw.dashboard import Dashboard
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 connect("cabal -v0 v2-run exe:saw-remote-api")
 view(DebugLog(err=None))
 view(LogResults())
+view(Dashboard(path=__file__))
 
 bcname = os.path.join(dir_path, 'salsa20.bc')
 cryname = os.path.join(dir_path, 'Salsa20.cry')
@@ -57,7 +58,7 @@ class QuarterRoundContract(Contract):
 
     def post(self):
         self.points_to(self.y0_p,
-                       self.cryptol("(@)")(self.cryptol("quarterround")([self.y0, self.y1, self.y2, self.y3]),
+                       self.cryptol("(@)")(self.cryptol("quarterround")([self.y0, self.y2, self.y2, self.y3]),
                                            self.cryptol("0")))
         self.points_to(self.y1_p,
                        self.cryptol("(@)")(self.cryptol("quarterround")([self.y0, self.y1, self.y2, self.y3]),

--- a/examples/salsa20.py
+++ b/examples/salsa20.py
@@ -58,7 +58,7 @@ class QuarterRoundContract(Contract):
 
     def post(self):
         self.points_to(self.y0_p,
-                       self.cryptol("(@)")(self.cryptol("quarterround")([self.y0, self.y2, self.y2, self.y3]),
+                       self.cryptol("(@)")(self.cryptol("quarterround")([self.y0, self.y1, self.y2, self.y3]),
                                            self.cryptol("0")))
         self.points_to(self.y1_p,
                        self.cryptol("(@)")(self.cryptol("quarterround")([self.y0, self.y1, self.y2, self.y3]),

--- a/examples/salsa20.py
+++ b/examples/salsa20.py
@@ -4,9 +4,12 @@ import os.path
 from cryptol.cryptoltypes import to_cryptol
 from saw.llvm import Contract, LLVMArrayType, uint8_t, uint32_t, void
 from saw import *
+from saw import dashboard
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 connect("cabal -v0 v2-run exe:saw-remote-api")
+view(DebugLog(err=None))
+view(LogResults())
 
 bcname = os.path.join(dir_path, 'salsa20.bc')
 cryname = os.path.join(dir_path, 'Salsa20.cry')

--- a/examples/swap.py
+++ b/examples/swap.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 from saw import *
+from saw.dashboard import Dashboard
 from saw.llvm import uint32_t, Contract, void
 
 import os
@@ -30,6 +31,8 @@ class Swap(Contract):
         self.returns(void)
 
 connect("cabal -v0 v2-run exe:saw-remote-api")
+view(DebugLog(err=None))
+view(LogResults())
 
 mod = llvm_load_module(swap_bc)
 

--- a/python/argo/connection.py
+++ b/python/argo/connection.py
@@ -6,9 +6,7 @@ import re
 import socket
 import subprocess
 import signal
-import sys  # pylint: disable=unused-import
-from typing import Any, Dict, List, Mapping, Optional, Union
-from mypy_extensions import TypedDict
+from typing import Any, Dict, Mapping, Optional, Union
 
 from . import netstring
 
@@ -90,7 +88,7 @@ class ServerProcess:
 
     def running(self) -> bool:
         """Check whether the process is still running."""
-        if self.proc.poll() is None:
+        if self.proc is not None and self.proc.poll() is None:
             return True
         else:
             return False

--- a/python/saw/__init__.py
+++ b/python/saw/__init__.py
@@ -279,7 +279,6 @@ def llvm_verify(module: LLVMModule,
     result: VerificationResult
     conn = __get_designated_connection()
     conn_snapshot = conn.snapshot()
-    abort_proof = False
 
     global __global_success
     global __designated_views
@@ -322,7 +321,6 @@ def llvm_verify(module: LLVMModule,
                                       assumptions=lemmas,
                                       contract=contract,
                                       exception=err)
-            abort_proof = True
     # If something else went wrong...
     except Exception as err:
         __global_success = False
@@ -342,7 +340,7 @@ def llvm_verify(module: LLVMModule,
 
     # Abort the proof if we failed to assume a failed verification, otherwise
     # return the result of the verification
-    if abort_proof:
+    if isinstance(result, AssumptionFailed):
         raise result.exception from None
 
     return result

--- a/python/saw/exceptions.py
+++ b/python/saw/exceptions.py
@@ -3,23 +3,35 @@ from itertools import chain
 from typing import Dict, Any, List, Iterable, Type
 from argo.interaction import ArgoException
 
-class SAWException(Exception):
-    data : Dict[str, Any]
-    code : int
 
-    def __init__(self, ae : ArgoException) -> None:
+class SAWException(Exception):
+    data: Dict[str, Any]
+    code: int
+    stdout: str
+    stderr: str
+
+    def __init__(self, ae: ArgoException) -> None:
         super().__init__(ae.message)
         self.data = ae.data
         self.code = ae.code
+        self.stdout = ae.stdout
+        self.stderr = ae.stderr
 
     # The exception gets fields for each data field in the ArgoException
-    def __getattr__(self, attr : str) -> Any:
+    def __getattr__(self, attr: str) -> Any:
         self.data.get(attr)
 
     def __dir__(self) -> Iterable[str]:
         return chain(super().__dir__(), [str(k) for k in self.data.keys()])
 
-def make_saw_exception(ae : ArgoException) -> SAWException:
+    def __str__(self) -> str:
+        lines: List[str] = []
+        for k, v in self.data.items():
+            lines.append(f"{k}: {v}")
+        return '\n'.join(lines)
+
+    
+def make_saw_exception(ae: ArgoException) -> SAWException:
     """Convert an ArgoException to its corresponding SAWException, failing with
     the original ArgoException if the code for this ArgoException does not
     correspond to a SAWException.


### PR DESCRIPTION
Working towards addressing #59 (but not resolving it)...

The Argo protocol now transmits the full captured stdout/err of the
method invoked back to the client, which may do with it what they
please. In the case of the Python client to the SAW server, this
information is exposed in the exceptions thrown, and in particular, to
the View implementations that can track and display this information as
if it was coming natively from the Python process.

To use this functionality in the Python client, add a `View` for it, as the salsa20 and swap examples do:

```python
connect("cabal -v0 v2-run exe:saw-remote-api")
view(DebugLog(err=None))
view(LogResults())
```

The two optional named parameters for `DebugLog` are `out` and `err` and direct the stdout/stderr of the invoked method to either the same output pipe (default), a given file handle, or into the void if specified as `None`.

Because the order of printing is dependent on the order you attach the `View`s, it's usually best to attach the debug-log and results-log in the order above, because that means you see the debug statements prior to the final result, as opposed to the other way.

This PR does not yet include documentation of this feature or protocol change, and we may want to add such before merging.