### PR TITLE
fix: allow BitVector param type to Cryptol fns

### DIFF
--- a/python/cryptol/cryptoltypes.py
+++ b/python/cryptol/cryptoltypes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from collections import OrderedDict
 from abc import ABCMeta, abstractmethod
 import base64
+from math import ceil
 import BitVector #type: ignore
 
 from typing import Any, Dict, Iterable, List, NoReturn, Optional, TypeVar, Union
@@ -150,10 +151,12 @@ class CryptolType:
                     'width': 8 * len(val),
                     'data': base64.b64encode(val).decode('ascii')}
         elif isinstance(val, BitVector.BitVector):
+            n = int(val)
+            byte_width = ceil(n.bit_length()/8)
             return {'expression': 'bits',
                     'encoding': 'base64',
                     'width': val.length(), # N.B. original length, not padded
-                    'data': base64.b64encode(bytes([int(val)])).decode('ascii')}
+                    'data': base64.b64encode(n.to_bytes(byte_width,'big')).decode('ascii')}
         else:
             raise TypeError("Unsupported value: " + str(val))
 

--- a/python/cryptol/cryptoltypes.py
+++ b/python/cryptol/cryptoltypes.py
@@ -155,7 +155,7 @@ class CryptolType:
             return {'expression': 'bits',
                     'encoding': 'base64',
                     'width': val.length(), # N.B. original length, not padded
-                    'data': copy.get_bitvector_in_hex()}
+                    'data': base64.b64encode(bytes(int(val))).decode('ascii')}
         else:
             raise TypeError("Unsupported value: " + str(val))
 
@@ -197,6 +197,8 @@ class Bitvector(CryptolType):
                     'encoding': 'base64',
                     'width': eval_numeric(self.width, 8 * len(val)),
                     'data': base64.b64encode(val).decode('ascii')}
+        elif isinstance(val, BitVector.BitVector):
+            return CryptolType.convert(self, val)
         else:
             raise ValueError(f"Not supported as bitvector: {val!r}")
 

--- a/python/cryptol/cryptoltypes.py
+++ b/python/cryptol/cryptoltypes.py
@@ -150,12 +150,10 @@ class CryptolType:
                     'width': 8 * len(val),
                     'data': base64.b64encode(val).decode('ascii')}
         elif isinstance(val, BitVector.BitVector):
-            copy = val.deep_copy()
-            copy.pad_from_left(copy.length() % 4)
             return {'expression': 'bits',
                     'encoding': 'base64',
                     'width': val.length(), # N.B. original length, not padded
-                    'data': base64.b64encode(bytes(int(val))).decode('ascii')}
+                    'data': base64.b64encode(bytes([int(val)])).decode('ascii')}
         else:
             raise TypeError("Unsupported value: " + str(val))
 


### PR DESCRIPTION
Should fix https://github.com/GaloisInc/argo/issues/110 - I've got a cryptol-remote-api test locally that successfully uses it, but nothing in this repo ... =\