### PR TITLE
Initial version of inline application documentation.

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -9,6 +9,9 @@ development artifacts can keep apprised of ongoing updates.
 Recent Changes
 ==============
 
+- Added a ``doc`` subcommand that causes documentation to be dumped
+  about the server.
+
 - Added a ``--public`` flag that causes the socket server to listen for
   external connections
 

--- a/argo/argo.cabal
+++ b/argo/argo.cabal
@@ -56,6 +56,8 @@ library
   exposed-modules:
     Argo
     Argo.DefaultMain
+    Argo.Doc
+    Argo.Doc.ReST
     Argo.Panic
     Argo.ServerState
     Argo.Socket

--- a/argo/argo.cabal
+++ b/argo/argo.cabal
@@ -57,6 +57,7 @@ library
     Argo
     Argo.DefaultMain
     Argo.Doc
+    Argo.Doc.Protocol
     Argo.Doc.ReST
     Argo.Panic
     Argo.ServerState

--- a/argo/src/Argo.hs
+++ b/argo/src/Argo.hs
@@ -20,7 +20,10 @@ module Argo
   ( -- * Primary interface to JSON-RPC
     App
   , mkApp
+  , appName
+  , appDocumentation
   -- * Defining methods
+  , AppMethod
   , MethodType(..)
   , Method(..)
   , runMethod
@@ -84,6 +87,7 @@ import System.IO.Silently
 import Text.Read (readMaybe)
 import Web.Scotty hiding (raise, params, get, put)
 
+import qualified Argo.Doc as Doc
 import Argo.ServerState
 import Argo.Netstring
 
@@ -120,13 +124,24 @@ data MethodType
 -- exception.
 method ::
   forall params result state.
-  (JSON.FromJSON params, JSON.ToJSON result) =>
+  (JSON.FromJSON params, Doc.DescribedParams params, JSON.ToJSON result) =>
+  Text ->
+  MethodType ->
+  Doc.Block ->
   (params -> Method state result) ->
-  (JSON.Value -> Method state JSON.Value)
-method f p =
-  case JSON.fromJSON @params p of
-    JSON.Error msg -> raise $ invalidParams msg p
-    JSON.Success params -> JSON.toJSON <$> f params
+  AppMethod state
+method name ty doc f =
+  let impl =
+        \p ->
+         case JSON.fromJSON @params p of
+           JSON.Error msg -> raise $ invalidParams msg p
+           JSON.Success params -> JSON.toJSON <$> f params
+  in AppMethod { _methodName = name
+               , _methodType = ty
+               , _methodImplementation = impl
+               , _methodParamDocs = Doc.parameterFieldDescription @params
+               , _methodDocs = doc
+               }
 
 -- | Get the logger from the server
 getDebugLogger :: Method state (Text -> IO ())
@@ -164,6 +179,8 @@ raise = liftIO . throwIO
 data App s =
   App { _serverState :: MVar (AppServerState s)
       , _appMethods :: Map Text (MethodType, JSON.Value -> Method s JSON.Value)
+      , _appName :: Text
+      , _appDocumentation :: [Doc.Block]
       }
 
 -- | Focus on the state var in an 'App'
@@ -175,16 +192,66 @@ appMethods ::
   Lens' (App s) (Map Text (MethodType, JSON.Value -> Method s JSON.Value))
 appMethods = lens _appMethods (\a s -> a { _appMethods = s })
 
+appName :: Lens' (App s) Text
+appName = lens _appName (\a n -> a { _appName = n })
+
+appDocumentation :: Lens' (App s) [Doc.Block]
+appDocumentation = lens _appDocumentation (\a d -> a { _appDocumentation = d })
+
+data AppMethod s =
+  AppMethod
+  { _methodName :: !Text
+  , _methodType :: !MethodType
+  , _methodImplementation :: !(JSON.Value -> Method s JSON.Value)
+  , _methodParamDocs :: ![(Text, Doc.Block)]
+  , _methodDocs :: !Doc.Block
+  }
+
+
+methodName :: Lens' (AppMethod s) Text
+methodName = lens _methodName (\m n -> m { _methodName = n })
+
+methodType :: Lens' (AppMethod s) MethodType
+methodType = lens _methodType (\m t -> m { _methodType = t })
+
+methodImplementation :: Lens' (AppMethod s) (JSON.Value -> Method s JSON.Value)
+methodImplementation = lens _methodImplementation (\m impl -> m { _methodImplementation = impl })
+
+methodParamDocs :: Lens' (AppMethod s) [(Text, Doc.Block)]
+methodParamDocs = lens _methodParamDocs (\m t -> m { _methodParamDocs = t })
+
+methodDocs :: Lens' (AppMethod s) Doc.Block
+methodDocs = lens _methodDocs (\m t -> m { _methodDocs = t })
+
+
 -- | Construct an application from an initial state and a mapping from method
 -- names to methods.
 mkApp ::
+  Text {- ^ Application name -} ->
+  [Doc.Block] {- ^ Documentation -} ->
   ((FilePath -> IO B.ByteString) -> IO s) {- ^ how to get the initial state -} ->
-  [(Text, MethodType, JSON.Value -> Method s JSON.Value)]
-  {- ^ method names paired with their implementations -} ->
+  [AppMethod s]
+  {- ^ Individual methods -} ->
   IO (App s)
-mkApp initAppState methods =
+mkApp name docs initAppState methods =
   App <$> (newMVar =<< initialState initAppState)
-      <*> pure (M.fromList [ (k, (v1, v2)) | (k, v1, v2) <- methods])
+      <*> pure (M.fromList [ (name, (ty, impl)) | AppMethod name ty impl _ _ <- methods])
+      <*> pure name
+      <*> pure (docs ++
+                [Doc.Section "Methods"
+                   [ Doc.Section (name <> " " <> mt ty)
+                       [ if null paramDocs
+                         then Doc.Paragraph [Doc.Text "No parameters"]
+                         else Doc.DescriptionList
+                              [ (Doc.Literal field, fieldDocs)
+                              | (field, fieldDocs) <- paramDocs
+                              ]
+                       , implDoc
+                       ]
+                   | AppMethod name ty _ paramDocs implDoc <- methods
+                   ]])
+
+  where mt ty = T.toLower (T.pack ("(" ++ show ty ++ ")"))
 
 -- | JSON RPC exceptions should be thrown by method implementations when
 -- they want to return an error.

--- a/argo/src/Argo.hs
+++ b/argo/src/Argo.hs
@@ -70,6 +70,7 @@ import Data.Binary.Builder
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as BS
 import Data.Foldable (for_)
+import Data.List.NonEmpty (NonEmpty(..))
 import Data.Map (Map)
 import qualified Data.Map as M
 import Data.Maybe (maybeToList)
@@ -243,7 +244,7 @@ mkApp name docs initAppState methods =
                        [ if null paramDocs
                          then Doc.Paragraph [Doc.Text "No parameters"]
                          else Doc.DescriptionList
-                              [ (Doc.Literal field, fieldDocs)
+                              [ (Doc.Literal field :| [], fieldDocs)
                               | (field, fieldDocs) <- paramDocs
                               ]
                        , implDoc

--- a/argo/src/Argo/DefaultMain.hs
+++ b/argo/src/Argo/DefaultMain.hs
@@ -25,6 +25,7 @@ import System.Exit (die)
 
 import Argo
 import qualified Argo.Doc as Doc
+import Argo.Doc.Protocol (protocolDocs)
 import Argo.Doc.ReST
 import Argo.Socket
 
@@ -335,7 +336,7 @@ realMain makeApp progMode =
           do theApp <- makeApp (DocOpts userOpts)
              T.putStrLn $
                restructuredText $
-                 Doc.App (view appName theApp) (view appDocumentation theApp)
+                 Doc.App (view appName theApp) (protocolDocs : view appDocumentation theApp)
 
   where maybeLog Nothing _ = pure ()
         maybeLog (Just StdErrLog) txt = T.hPutStrLn stderr txt

--- a/argo/src/Argo/Doc.hs
+++ b/argo/src/Argo/Doc.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Argo.Doc (LinkTarget(..), Block(..), Inline(..), Described(..), DescribedParams(..), datatype) where
+
+import Data.Text (Text)
+import Data.Typeable
+
+data LinkTarget
+  = URL Text
+  | TypeDesc TypeRep
+
+data Block
+  = Section Text [Block]
+  | Datatype TypeRep Text [Block]
+  | App Text [Block]
+  | Paragraph [Inline]
+  | DescriptionList [(Inline, Block)]
+  | BulletedList [Block]
+
+data Inline
+  = Text Text
+  | Link LinkTarget Text
+  | Literal Text
+
+class Described a where
+  typeName :: Text
+  description :: [Block]
+
+class DescribedParams a where
+  parameterFieldDescription :: [(Text, Block)]
+
+datatype :: forall a . (Typeable a, Described a) => Block
+datatype =
+  Datatype (typeRep (Proxy @a)) (typeName @a) (description @a)

--- a/argo/src/Argo/Doc.hs
+++ b/argo/src/Argo/Doc.hs
@@ -4,6 +4,7 @@
 
 module Argo.Doc (LinkTarget(..), Block(..), Inline(..), Described(..), DescribedParams(..), datatype) where
 
+import Data.List.NonEmpty
 import Data.Text (Text)
 import Data.Typeable
 
@@ -16,7 +17,7 @@ data Block
   | Datatype TypeRep Text [Block]
   | App Text [Block]
   | Paragraph [Inline]
-  | DescriptionList [(Inline, Block)]
+  | DescriptionList [(NonEmpty Inline, Block)]
   | BulletedList [Block]
 
 data Inline

--- a/argo/src/Argo/Doc.hs
+++ b/argo/src/Argo/Doc.hs
@@ -25,10 +25,21 @@ data Inline
   | Link LinkTarget Text
   | Literal Text
 
+-- | This class provides the canonical documentation for a datatype
+-- that occurs as part of a protocol message (in other words, it
+-- documents the @FromJSON@ and @ToJSON@ instances). The type variable
+-- does not occur in the method's signature because it is intended to
+-- be used with the @TypeApplications@ extension to GHC Haskell.
 class Described a where
   typeName :: Text
   description :: [Block]
 
+
+-- | This class provides the canonical documentation for a datatype
+-- that is deserialized as parameters to some method via a @FromJSON@
+-- instance. The type variable does not occur in the method's
+-- signature because it is intended to be used with the
+-- @TypeApplications@ extension to GHC Haskell.
 class DescribedParams a where
   parameterFieldDescription :: [(Text, Block)]
 

--- a/argo/src/Argo/Doc/Protocol.hs
+++ b/argo/src/Argo/Doc/Protocol.hs
@@ -1,0 +1,97 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Argo.Doc.Protocol (protocolDocs) where
+
+import Data.List.NonEmpty (NonEmpty(..))
+
+import Argo.Doc
+
+
+-- | Documentation for the details shared by all servers that use this library.
+protocolDocs :: Block
+protocolDocs =
+  Section "Fundamental Protocol" $
+   [ Paragraph
+     [ Text "This application is a "
+     , Link (URL "https://www.jsonrpc.org/specification") "JSON-RPC"
+     , Text $
+       " server. Additionally, it maintains a persistent cache " <>
+       "of application states and explicitly indicates the state " <>
+       "in which each command is to be carried out."]
+   , Section "Transport"
+     [ Paragraph [Text "The server supports three transport methods:"]
+     , DescriptionList
+       [ ( Literal "stdio" :| []
+         , Paragraph [ Text "in which the server communicates over"
+                     , Literal "stdin", Text "and", Literal "stdout"
+                     ]
+         )
+       , ( Text "Socket" :| []
+          , Paragraph [ Text "in which the server communicates over"
+                      , Literal "stdin", Text "and", Literal "stdout"
+                      ]
+          )
+       , ( Text "HTTP" :| []
+         , Paragraph [Text "in which the server communicates over HTTP"]
+         )
+       ]
+     , Paragraph
+       [ Text "In both", Literal "stdio", Text "and socket mode, "
+       , Text "messages are delimited using "
+       , Link (URL "http://cr.yp.to/proto/netstrings.txt") "netstrings."
+       ]
+     ]
+   , Section "Application State"
+     [ Paragraph
+       [ Text "According to the JSON-RPC specification, the ", Literal "params", Text " field in a "
+       , Text "message object must be an array or object. In this protocol, it is "
+       , Text "always an object. While each message may specify its own arguments, "
+       , Text "every message has a parameter field named ", Literal "state", Text "."]
+     , Paragraph
+       [ Text "When the first message is sent from the client to the server, the "
+       , Literal "state", Text " parameter should be initialized to the JSON null value "
+       , Literal "null", Text ". Replies from the server may contain a new state that should "
+       , Text "be used in subsequent requests, so that state changes executed by the "
+       , Text "request are visible. Prior versions of this protocol represented the "
+       , Text "initial state as the empty array ", Literal "[]", Text ", but this is now deprecated "
+       , Text "and will be removed."
+       ]
+     , Paragraph
+       [ Text "In particular, per JSON-RPC, non-error replies are always a JSON "
+       , Text "object that contains a ", Literal "result", Text " field. The result field always "
+       , Text "contains an ", Literal "answer", Text " field and a ", Literal "state"
+       , Text " field, as well as ", Literal "stdout", Text " and ", Literal "stderr", Text "."
+       ]
+     , DescriptionList
+       [ (k, Paragraph v)
+       | (k, v) <-
+         [ ( Literal "answer" :| []
+           , [ Text "The value returned as a response to the request "
+             , Text "(the precise contents depend on which request was sent)"
+             ]
+           )
+         , ( Literal "state" :| []
+           , [ Text "The state, to be sent in subsequent requests. If the server did not "
+             , Text "modify its state in response to the command, then this state may be "
+             , Text "the same as the one sent by the client."
+             ]
+           )
+         , ( Literal "stdout" :| [Text " and ", Literal "stderr"]
+           , [ Text "These fields contain the contents of the Unix ", Literal "stdout", Text " and "
+             , Literal "stderr", Text " file descriptors. They are intended as a stopgap measure "
+             , Text "for clients who are still in the process of obtaining structured "
+             , Text "information from the libraries on which they depend, so that "
+             , Text "information is not completely lost to users. However, the server may "
+             , Text "or may not cache this information and resend it. Applications are "
+             , Text "encouraged to used structured data and send it deliberately as the answer."
+             ]
+           )
+         ]
+       ]
+       , Paragraph
+         [ Text "The precise structure of states is considered an implementation detail "
+         , Text "that could change at any time. Please treat them as opaque tokens that "
+         , Text "may be saved and re-used within a given server process, but not "
+         , Text "created by the client directly."
+         ]
+       ]
+   ]

--- a/argo/src/Argo/Doc/ReST.hs
+++ b/argo/src/Argo/Doc/ReST.hs
@@ -33,6 +33,7 @@ restructuredText block =
     go (Datatype t name contents) =
       do anchor (mangle (show t))
          header name
+         terpri
          nestSection (traverse_ go contents)
          terpri
     go (App name contents) = go (Section name contents)
@@ -44,6 +45,7 @@ restructuredText block =
         do terpri
            inline name
            indented $ terpri >> go what
+           terpri
     go (BulletedList elts) =
       for_ elts $
         \contents ->

--- a/argo/src/Argo/Doc/ReST.hs
+++ b/argo/src/Argo/Doc/ReST.hs
@@ -1,0 +1,116 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Argo.Doc.ReST (restructuredText) where
+
+import Control.Monad.Reader
+import Control.Monad.Writer
+import Data.Char
+import Data.Foldable
+import Data.Text (Text)
+import qualified Data.Text as T
+import Numeric.Natural
+
+import Argo.Doc
+
+data ReSTContext =
+  ReSTContext
+  { sectionNestingLevel :: Natural
+  , textIndentLevel :: Natural
+  }
+
+
+restructuredText :: Block -> Text
+restructuredText block =
+  execWriter $ runReaderT (go block) $ ReSTContext 0 0
+  where
+    go :: Block -> ReaderT ReSTContext (Writer Text) ()
+    go (Section name contents) =
+      do header name
+         terpri
+         nestSection (traverse_ go contents)
+         terpri
+    go (Datatype t name contents) =
+      do anchor (mangle (show t))
+         header name
+         nestSection (traverse_ go contents)
+         terpri
+    go (App name contents) = go (Section name contents)
+    go (Paragraph contents) =
+      do traverse_ inline contents
+         terpri >> terpri
+    go (DescriptionList elts) =
+      for_ elts $ \(name, what) ->
+        do terpri
+           inline name
+           indented $ terpri >> go what
+    go (BulletedList elts) =
+      for_ elts $
+        \contents ->
+          do terpri
+             tell "* "
+             indented (go contents)
+             terpri
+
+    nestSection ::
+      ReaderT ReSTContext (Writer Text) a ->
+      ReaderT ReSTContext (Writer Text) a
+    nestSection =
+      local $ \(ReSTContext lvl indent) -> ReSTContext (lvl + 1) indent
+
+    indented ::
+      ReaderT ReSTContext (Writer Text) a ->
+      ReaderT ReSTContext (Writer Text) a
+    indented =
+      local $ \(ReSTContext lvl indent) -> ReSTContext lvl (indent + 2)
+
+    inline :: Inline -> ReaderT ReSTContext (Writer Text) ()
+    inline (Text txt) = traverse_ tell $ T.lines txt
+    inline (Link tgt label) =
+      case tgt of
+        URL url -> tell $ "`" <> label <> " <" <> url <> ">`_"
+        TypeDesc t -> tell $ ":ref:`" <> label <> " <" <> mangle (show t) <> ">`"
+    inline (Literal txt) = tell $ "``" <> txt <> "``"
+
+    terpri :: ReaderT ReSTContext (Writer Text) ()
+    terpri =
+      do i <- asks textIndentLevel
+         tell "\n"
+         tell (T.replicate (fromIntegral i) " ")
+
+    anchor :: Text -> ReaderT ReSTContext (Writer Text) ()
+    anchor name = tell $ ".. _" <> name <> ":\n"
+
+    mangle :: String -> Text
+    mangle [] = ""
+    mangle (c:cs)
+      | isAlphaNum c = T.singleton c <> mangle cs
+      | c == '-' = "_dash_" <> mangle cs
+      | c == '>' = "_greater_" <> mangle cs
+      | c == '<' = "_less_" <> mangle cs
+      | c == '(' = "_lpar_" <> mangle cs
+      | c == ')' = "_rpar_" <> mangle cs
+      | c == ' ' = "_space_" <> mangle cs
+      | c == ':' = "_colon_" <> mangle cs
+      | c == '~' = "_twiddle_" <> mangle cs
+      | c == '[' = "_lsq_" <> mangle cs
+      | c == ']' = "_rsq_" <> mangle cs
+      | c == '*' = "_splat_" <> mangle cs
+      | otherwise = "___" <> mangle cs
+
+
+    header :: Text -> ReaderT ReSTContext (Writer Text) ()
+    header name =
+      do tell name
+         terpri
+         c <- headerChar
+         tell $ T.replicate (T.length name) (T.singleton c)
+         terpri
+
+    headerChar =
+      do lvl <- asks sectionNestingLevel
+         pure (getC lvl "=-~+*#`_")
+      where getC _ [] = error "Nesting too deep in docs"
+            getC n (c:cs)
+              | n == 0 = c
+              | otherwise = getC (n - 1) cs

--- a/argo/src/Argo/Doc/ReST.hs
+++ b/argo/src/Argo/Doc/ReST.hs
@@ -43,7 +43,7 @@ restructuredText block =
     go (DescriptionList elts) =
       for_ elts $ \(name, what) ->
         do terpri
-           inline name
+           traverse_ inline name
            indented $ terpri >> go what
            terpri
     go (BulletedList elts) =

--- a/file-echo-api/file-echo-api/Main.hs
+++ b/file-echo-api/file-echo-api/Main.hs
@@ -1,34 +1,44 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PartialTypeSignatures #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 module Main ( main ) where
 
 import qualified Data.Aeson as JSON
-import           Data.ByteString ( ByteString )
+import Data.ByteString (ByteString)
 import Data.Text (Text)
+import Data.Typeable
 
 import qualified Argo as Argo
-import Argo.DefaultMain ( defaultMain )
+import qualified Argo.Doc as Doc
+import Argo.DefaultMain (defaultMain)
 
 
 import qualified FileEchoServer as FES
 
 main :: IO ()
 main =
-  do theApp <- Argo.mkApp mkInitState serverMethods
+  do theApp <- Argo.mkApp "File echo server" docs mkInitState serverMethods
      defaultMain description theApp
+
+docs :: [Doc.Block]
+docs =
+  [ Doc.Paragraph [Doc.Text "A sample server that demonstrates filesystem caching."]
+  , Doc.Section "Datatypes" [Doc.datatype @FES.Ignorable]
+  ]
 
 description :: String
 description =
   "An RPC server for loading and printing files."
 
 mkInitState :: (FilePath -> IO ByteString) -> IO FES.ServerState 
-mkInitState = const $ FES.initialState
+mkInitState = const FES.initialState
 
-serverMethods :: [(Text, Argo.MethodType, JSON.Value -> Argo.Method FES.ServerState JSON.Value)]
+serverMethods :: [Argo.AppMethod FES.ServerState]
 serverMethods =
-  [ ("load",           Argo.Command,   Argo.method FES.loadCmd)
-  , ("clear",          Argo.Command,   Argo.method FES.clearCmd)
-  , ("implode",        Argo.Query,     Argo.method FES.implodeCmd)
-  , ("show",           Argo.Query,     Argo.method FES.showCmd)
+  [ Argo.method "load" Argo.Command (Doc.Paragraph [Doc.Text "Load a file from disk into memory."]) FES.loadCmd
+  , Argo.method "clear" Argo.Command (Doc.Paragraph [Doc.Text "Forget the loaded file."]) FES.clearCmd
+  , Argo.method "implode" Argo.Query (Doc.Paragraph [Doc.Text "Throw an error immediately."]) FES.implodeCmd
+  , Argo.method "show" Argo.Query (Doc.Paragraph [Doc.Text "Show a substring of the file."]) FES.showCmd
+  , Argo.method "ignore" Argo.Query (Doc.Paragraph [Doc.Text "Ignore an ", Doc.Link (Doc.TypeDesc (typeRep (Proxy @FES.Ignorable))) "ignorable value", Doc.Text "."]) FES.ignoreCmd
   ]

--- a/file-echo-api/src/FileEchoServer.hs
+++ b/file-echo-api/src/FileEchoServer.hs
@@ -180,11 +180,11 @@ instance Doc.Described Ignorable where
   description =
     [ Doc.Paragraph [Doc.Text "Data to be ignored can take one of three forms:"]
     , Doc.DescriptionList
-        [ (Doc.Literal "true",
+        [ (pure $ Doc.Literal "true",
            Doc.Paragraph [Doc.Text "The first ignorable value"])
-        , (Doc.Literal "false",
+        , (pure $ Doc.Literal "false",
            Doc.Paragraph [Doc.Text "The second ignorable value"])
-        , (Doc.Literal "null",
+        , (pure $ Doc.Literal "null",
            Doc.Paragraph [Doc.Text "The ultimate ignorable value, neither true nor false"])
         ]
     , Doc.Paragraph [Doc.Text "Nothing else may be ignored."]


### PR DESCRIPTION
This is a breaking change for client applications, but not for their clients.

The idea is to gently guide application implementors into adding documentation at various points. Right now, it renders to ReST, but it can be extended to render to other formats in the future. I hope that it can be used to generate what Sphinx is getting as input, and that it will ease the task of keeping docs and code in sync.

Outputting plain text is an easy extension, while Markdown might be a bit harder due to the inability to arbitrarily nest Markdown docs. A best-effort "markdown" would be easy as well, though.