### PR TITLE
Make logging more consistent

### DIFF
--- a/argo/src/Argo/Netstring.hs
+++ b/argo/src/Argo/Netstring.hs
@@ -26,7 +26,7 @@ import qualified Data.ByteString.Lazy as BS
 import qualified Data.ByteString.Builder as BS
 
 import Data.Word
-import System.IO
+import System.IO (Handle, hIsEOF)
 
 data BadNetstring
   = BadLength


### PR DESCRIPTION
Now logging _should_ be disabled for for all transport modes unless
explicitly requested.