### PR TITLE
Allow Argo apps to extend the command-line interface

### DIFF
--- a/file-echo-api/file-echo-api.cabal
+++ b/file-echo-api/file-echo-api.cabal
@@ -34,6 +34,7 @@ common deps
     directory            ^>= 1.3.1,
     filepath             ^>= 1.4,
     lens                 >= 4.17 && < 4.20,
+    optparse-applicative >= 0.14 && < 0.17,
     scientific           ^>= 0.3,
     text                 ^>= 1.2.3,
     unordered-containers ^>= 0.2,

--- a/file-echo-api/file-echo-api/Main.hs
+++ b/file-echo-api/file-echo-api/Main.hs
@@ -6,24 +6,37 @@ module Main ( main ) where
 import qualified Data.Aeson as JSON
 import           Data.ByteString ( ByteString )
 import Data.Text (Text)
+import qualified Options.Applicative as Opt
 
 import qualified Argo as Argo
-import Argo.DefaultMain ( defaultMain )
+import Argo.DefaultMain ( customMain, userOptions )
 
 
 import qualified FileEchoServer as FES
 
 main :: IO ()
-main =
-  do theApp <- Argo.mkApp mkInitState serverMethods
-     defaultMain description theApp
+main = customMain parseServerOptions parseServerOptions parseServerOptions description getApp
+  where
+    getApp opts =
+      Argo.mkApp (mkInitState $ userOptions opts) serverMethods
 
 description :: String
 description =
   "An RPC server for loading and printing files."
 
-mkInitState :: (FilePath -> IO ByteString) -> IO FES.ServerState 
-mkInitState = const $ FES.initialState
+mkInitState :: ServerOptions -> (FilePath -> IO ByteString) -> IO FES.ServerState
+mkInitState opts reader = FES.initialState (initialFile opts) reader
+
+newtype ServerOptions = ServerOptions { initialFile :: Maybe FilePath }
+
+parseServerOptions :: Opt.Parser ServerOptions
+parseServerOptions = ServerOptions <$> filename
+  where
+    filename =
+      Opt.optional $ Opt.strOption $
+      Opt.long "file" <>
+      Opt.metavar "FILENAME" <>
+      Opt.help "Initial file to echo"
 
 serverMethods :: [(Text, Argo.MethodType, JSON.Value -> Argo.Method FES.ServerState JSON.Value)]
 serverMethods =

--- a/file-echo-api/file-echo-api/Main.hs
+++ b/file-echo-api/file-echo-api/Main.hs
@@ -29,6 +29,9 @@ mkInitState opts reader = FES.initialState (initialFile opts) reader
 
 newtype ServerOptions = ServerOptions { initialFile :: Maybe FilePath }
 
+-- This function parses additional options used by this particular
+-- application. The ordinary Argo options are still parsed, and these
+-- are appended.
 parseServerOptions :: Opt.Parser ServerOptions
 parseServerOptions = ServerOptions <$> filename
   where

--- a/file-echo-api/test-scripts/file-echo-tests.py
+++ b/file-echo-api/test-scripts/file-echo-tests.py
@@ -207,3 +207,12 @@ post_response = requests.request('POST', "http://localhost:8080/", headers=good_
 assert(post_response.status_code == 200)
 
 os.killpg(os.getpgid(p_http.pid), signal.SIGKILL)
+
+# Test the custom command line argument to load a file at server start
+hello_file = file_dir.joinpath('hello.txt')
+c_preload = argo.ServerConnection(
+              argo.StdIOProcess("cabal v2-exec file-echo-api --verbose=0 -- stdio --file \"" + str(hello_file) + "\""))
+uid = c_preload.send_message("show", {"state": None})
+actual = c_preload.wait_for_reply_to(uid)
+expected = {'result':{'state':None,'stdout':'','stderr':'','answer':{'value':'Hello World!\n'}},'jsonrpc':'2.0','id':uid}
+assert(actual == expected)


### PR DESCRIPTION
Provide a more flexible "main" that allows Argo apps to enrich the
collection of allowed command-line arguments, and then construct the
application and initial state based on them.

This is part of https://github.com/GaloisInc/cryptol/issues/1009, and should probably not be merged until the Cryptol side has been implemented.