### PR TITLE
Add an option to avoid using `hCapture`

### DIFF
--- a/argo/src/Argo.hs
+++ b/argo/src/Argo.hs
@@ -482,7 +482,7 @@ instance JSON.ToJSON a => JSON.ToJSON (Response StateID a) where
         ]
       ]
 
--- | A wrapper around `hCapture` with a type signature tht allows for no
+-- | A wrapper around `hCapture` with a type signature that allows for no
 -- result, to allow easy toggling between silencing and capturing.
 hCaptureWrap :: [Handle] -> IO a -> IO (Maybe String, a)
 hCaptureWrap hs a =

--- a/argo/src/Argo/Socket.hs
+++ b/argo/src/Argo/Socket.hs
@@ -28,12 +28,13 @@ listenQueueDepth = 10
 -- A reasonable default host name is "::", and a reasonable default
 -- service name is a port number as a string, e.g. "10000".
 serveSocket ::
+  Bool              {- ^ True to work on read-only file system -} ->
   (Text -> IO ())   {- ^ logger            -} ->
   N.HostName        {- ^ host              -} ->
   N.ServiceName     {- ^ port              -} ->
   App s             {- ^ rpc application   -} ->
   IO ()             {- ^ start application -}
-serveSocket logger hostName serviceName app =
+serveSocket readOnly logger hostName serviceName app =
 
      -- resolve listener addresses, throws exception on failure
   do infos <- N.getAddrInfo (Just hints) (Just hostName) (Just serviceName)
@@ -42,17 +43,18 @@ serveSocket logger hostName serviceName app =
      -- one per address family.
      forConcurrently_ infos $ \info ->
        do s <- startListening info
-          forever (acceptClient logger app s)
+          forever (acceptClient readOnly logger app s)
 
 -- | Start listening on a single, dynamically assigned port.
 -- The resulting worker thread and dynamically assigned port
 -- number are returned on success.
 serveSocketDynamic ::
+  Bool              {- ^ True to work on read-only file system -} ->
   (Text -> IO ())   {- ^ Logger            -} ->
   N.HostName        {- ^ IP address        -} ->
   App s             {- ^ RPC application   -} ->
   IO (Async (), N.PortNumber)
-serveSocketDynamic logger hostName app =
+serveSocketDynamic readOnly logger hostName app =
 
      -- resolve listener addresses, throws exception on failure
   do let hint1 =
@@ -65,7 +67,7 @@ serveSocketDynamic logger hostName app =
        _      -> fail "serveSocketDynamic: host resolved as too many addresses"
 
      s <- startListening info
-     a <- async (forever (acceptClient logger app s))
+     a <- async (forever (acceptClient readOnly logger app s))
      p <- N.socketPort s
      return (a, p)
 
@@ -84,15 +86,15 @@ startListening addr =
 
 -- | Accept a new connection on the given listening socket and
 -- start processing rpc requests.
-acceptClient :: (Text -> IO ()) -> App s -> N.Socket -> IO ()
-acceptClient logMessage app s =
+acceptClient :: Bool -> (Text -> IO ()) -> App s -> N.Socket -> IO ()
+acceptClient readOnly logMessage app s =
 
   do (c, peer) <- N.accept s
      h         <- N.socketToHandle c ReadWriteMode
      -- don't use c after this, it is owned by h
 
      logMessage (pack ("CONNECT: " ++ show peer))
-     _ <- forkFinally (serveHandlesNS logMessage h h app) $ \res ->
+     _ <- forkFinally (serveHandlesNS readOnly logMessage h h app) $ \res ->
        do case res of
             Right _ -> logMessage (pack ("CLOSE: " ++ show peer))
             Left e  -> logMessage (pack ("ERROR: " ++ show peer ++ " " ++ displayException e))

--- a/argo/src/Argo/Socket.hs
+++ b/argo/src/Argo/Socket.hs
@@ -13,7 +13,7 @@ import System.IO                (IOMode(ReadWriteMode), hClose, stderr)
 
 import qualified Network.Socket as N
 
-import Argo (App, serveHandlesNS)
+import Argo (App, MethodOptions(..), serveHandlesNS)
 
 -- | Arbitrarily chosen value for number of connects to hold
 -- in queue during a burst of connections before they are
@@ -28,13 +28,12 @@ listenQueueDepth = 10
 -- A reasonable default host name is "::", and a reasonable default
 -- service name is a port number as a string, e.g. "10000".
 serveSocket ::
-  Bool              {- ^ True to work on read-only file system -} ->
-  (Text -> IO ())   {- ^ logger            -} ->
+  MethodOptions     {- ^ options for how to execute methods -} ->
   N.HostName        {- ^ host              -} ->
   N.ServiceName     {- ^ port              -} ->
   App s             {- ^ rpc application   -} ->
   IO ()             {- ^ start application -}
-serveSocket readOnly logger hostName serviceName app =
+serveSocket opts hostName serviceName app =
 
      -- resolve listener addresses, throws exception on failure
   do infos <- N.getAddrInfo (Just hints) (Just hostName) (Just serviceName)
@@ -43,18 +42,17 @@ serveSocket readOnly logger hostName serviceName app =
      -- one per address family.
      forConcurrently_ infos $ \info ->
        do s <- startListening info
-          forever (acceptClient readOnly logger app s)
+          forever (acceptClient opts app s)
 
 -- | Start listening on a single, dynamically assigned port.
 -- The resulting worker thread and dynamically assigned port
 -- number are returned on success.
 serveSocketDynamic ::
-  Bool              {- ^ True to work on read-only file system -} ->
-  (Text -> IO ())   {- ^ Logger            -} ->
+  MethodOptions     {- ^ options for how to execute methods -} ->
   N.HostName        {- ^ IP address        -} ->
   App s             {- ^ RPC application   -} ->
   IO (Async (), N.PortNumber)
-serveSocketDynamic readOnly logger hostName app =
+serveSocketDynamic opts hostName app =
 
      -- resolve listener addresses, throws exception on failure
   do let hint1 =
@@ -67,7 +65,7 @@ serveSocketDynamic readOnly logger hostName app =
        _      -> fail "serveSocketDynamic: host resolved as too many addresses"
 
      s <- startListening info
-     a <- async (forever (acceptClient readOnly logger app s))
+     a <- async (forever (acceptClient opts app s))
      p <- N.socketPort s
      return (a, p)
 
@@ -86,15 +84,16 @@ startListening addr =
 
 -- | Accept a new connection on the given listening socket and
 -- start processing rpc requests.
-acceptClient :: Bool -> (Text -> IO ()) -> App s -> N.Socket -> IO ()
-acceptClient readOnly logMessage app s =
+acceptClient :: MethodOptions -> App s -> N.Socket -> IO ()
+acceptClient opts app s =
 
   do (c, peer) <- N.accept s
      h         <- N.socketToHandle c ReadWriteMode
+     let logMessage = optLogger opts
      -- don't use c after this, it is owned by h
 
      logMessage (pack ("CONNECT: " ++ show peer))
-     _ <- forkFinally (serveHandlesNS readOnly logMessage h h app) $ \res ->
+     _ <- forkFinally (serveHandlesNS opts h h app) $ \res ->
        do case res of
             Right _ -> logMessage (pack ("CLOSE: " ++ show peer))
             Left e  -> logMessage (pack ("ERROR: " ++ show peer ++ " " ++ displayException e))

--- a/file-echo-api/file-echo-api/Main.hs
+++ b/file-echo-api/file-echo-api/Main.hs
@@ -15,7 +15,7 @@ import Argo.DefaultMain ( customMain, userOptions )
 import qualified FileEchoServer as FES
 
 main :: IO ()
-main = customMain False parseServerOptions parseServerOptions parseServerOptions description getApp
+main = customMain parseServerOptions parseServerOptions parseServerOptions description getApp
   where
     getApp opts =
       Argo.mkApp (mkInitState $ userOptions opts) serverMethods

--- a/file-echo-api/file-echo-api/Main.hs
+++ b/file-echo-api/file-echo-api/Main.hs
@@ -15,7 +15,7 @@ import Argo.DefaultMain ( customMain, userOptions )
 import qualified FileEchoServer as FES
 
 main :: IO ()
-main = customMain parseServerOptions parseServerOptions parseServerOptions description getApp
+main = customMain False parseServerOptions parseServerOptions parseServerOptions description getApp
   where
     getApp opts =
       Argo.mkApp (mkInitState $ userOptions opts) serverMethods

--- a/file-echo-api/test-scripts/file-echo-tests.py
+++ b/file-echo-api/test-scripts/file-echo-tests.py
@@ -78,7 +78,7 @@ def run_tests(c):
     # Method not found
     uid = c.send_message("bad function", {"state": cleared_state})
     actual = c.wait_for_reply_to(uid)
-    expected = {'error':{'data':{'stdout':'','data':'bad function','stderr':''},'code':-32601,'message':'Method not found'},'jsonrpc':'2.0','id':uid}
+    expected = {'error':{'data':{'stdout':None,'data':'bad function','stderr':None},'code':-32601,'message':'Method not found'},'jsonrpc':'2.0','id':uid}
     assert(actual == expected)
 
     # Invalid params
@@ -107,14 +107,14 @@ def run_tests(c):
     # send a request with an invalid state id
     uid = c.send_message("show", {"state": "12345678-9101-1121-3141-516171819202"})
     actual = c.wait_for_reply_to(uid)
-    expected = {'error':{'data':{'stdout':'','data':'12345678-9101-1121-3141-516171819202','stderr':''},'code':20,'message':'Unknown state ID'},'jsonrpc':'2.0','id':uid}
+    expected = {'error':{'data':{'stdout':None,'data':'12345678-9101-1121-3141-516171819202','stderr':None},'code':20,'message':'Unknown state ID'},'jsonrpc':'2.0','id':uid}
     assert(actual == expected)
 
     # invalid request (missing JSON-RPC required fields)
     invalid_request = {'jsonrpc': '2.0','method': 'bad request', 'id':1}
     c.process.send_one_message(json.dumps(invalid_request))
     actual = c.wait_for_reply_to(None)
-    expected = {'error':{'data':{'stdout':'','data':'Error in $: key \"params\" not found','stderr':''},'code':-32700,'message':'Parse error'},'jsonrpc':'2.0','id':None}
+    expected = {'error':{'data':{'stdout':None,'data':'Error in $: key \"params\" not found','stderr':None},'code':-32700,'message':'Parse error'},'jsonrpc':'2.0','id':None}
     assert(actual == expected)
 
    # invalid request (Bad JSON)
@@ -122,7 +122,7 @@ def run_tests(c):
     c.process.send_one_message(invalid_request)
     time.sleep(2) # pause before fetching response so we don't just read the previous response whose JSON-RPC id is `null`
     actual = c.wait_for_reply_to(None)
-    expected = {'error':{'data':{'stdout':'','data':'Error in $: Failed reading: not a valid json value at \'BAAAAADJSON\'','stderr':''},'code':-32700,'message':'Parse error'},'jsonrpc':'2.0','id':None}
+    expected = {'error':{'data':{'stdout':None,'data':'Error in $: Failed reading: not a valid json value at \'BAAAAADJSON\'','stderr':None},'code':-32700,'message':'Parse error'},'jsonrpc':'2.0','id':None}
     assert(actual == expected)
 
 


### PR DESCRIPTION
This allows `argo` to work on a read-only file system. Or, at least, it should. If we discover any other file writes in the codebase, we can turn them off with the same option.

The one open question I have is whether the read-only option and the logger should be packaged together into some sort of more general record of options.