### PR TITLE
feat: bound memory usage by server

### DIFF
--- a/argo/argo.cabal
+++ b/argo/argo.cabal
@@ -46,6 +46,7 @@ common deps
     scotty                      ^>= 0.12,
     silently                    ^>= 1.2,
     text                        ^>= 1.2.3,
+    time,
     unordered-containers        ^>= 0.2,
     uuid                        ^>= 1.3,
     wai                         ^>= 3.2.2,

--- a/argo/src/Argo.hs
+++ b/argo/src/Argo.hs
@@ -62,7 +62,12 @@ module Argo
   , serveHttp
   -- * Request identifiers
   , RequestID(..)
-  , StateID
+  , StateID,
+  -- * System info
+  getFileSystemMode,
+  -- * AppMethod info
+  methodName, methodType, methodImplementation,
+  methodParamDocs, methodDocs
   ) where
 
 import Control.Concurrent
@@ -82,7 +87,7 @@ import Data.Map (Map)
 import qualified Data.Map as M
 import Data.Maybe (maybeToList)
 import Data.Scientific (Scientific)
-import Data.Text (Text)
+import Data.Text ( Text )
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
 import GHC.Stack

--- a/argo/src/Argo/DefaultMain.hs
+++ b/argo/src/Argo/DefaultMain.hs
@@ -86,12 +86,12 @@ parseNoOpts = pure NoOpts
 -- like socket and HTTP.
 data NetworkOptions =
   NetworkOptions
-  { networkSession :: Maybe Session
+  { _networkSession :: Maybe Session
     -- ^ The name of an existing session to re-establish
-  , networkHost :: Maybe HostName
+  , _networkHost :: Maybe HostName
     -- ^ The hostname on which to listen (e.g. "::" or "0.0.0.0" for
     -- public services)
-  , networkPort :: Maybe Port
+  , _networkPort :: Maybe Port
     -- ^ The port number on which to listen
   }
 
@@ -340,9 +340,9 @@ realMain makeApp globalOpts =
     StdIONetstring userOpts ->
       do theApp <- makeApp (StdIOOpts userOpts)
          serveStdIONS opts theApp
-    SocketNetstring (NetworkOptions session hostName port) userOpts ->
+    SocketNetstring (NetworkOptions session hostName netPort) userOpts ->
       do theApp <- makeApp (SocketOpts userOpts)
-         sessionResult <- getOrLockSession session hostName port
+         sessionResult <- getOrLockSession session hostName netPort
          let hostname = fromMaybe (selectHost hostName) hostName
          hSetBuffering stdout NoBuffering
          case sessionResult of
@@ -361,12 +361,12 @@ realMain makeApp globalOpts =
                    <> existingPort
                    <> ", not the specified port "
                    <> desiredPort
-    Http path (NetworkOptions session _host port) userOpts ->
+    Http path (NetworkOptions session _host netPort) userOpts ->
       do theApp <- makeApp (HttpOpts userOpts)
          case session of
            Just _ -> die "Named sessions not yet supported for HTTP"
            Nothing ->
-             serveHttp opts path theApp (maybe 8080 (read . unPort) port)
+             serveHttp opts path theApp (maybe 8080 (read . unPort) netPort)
     Doc format userOpts ->
       case format of
         ReST ->

--- a/argo/src/Argo/ServerState.hs
+++ b/argo/src/Argo/ServerState.hs
@@ -6,23 +6,32 @@
 module Argo.ServerState (
   -- * The server's state, which wraps app states
   ServerState,
-  initialState,
-  saveNewState,
-  -- ** Lenses into the server's state
-  appStateCache,
-  -- * File caching
-  freshStateReader,
+  initServerState,
+  saveNewAppState,
+  -- * Server launch options
+  ServerOpts, defaultServerOpts, optEphemeralCacheLimit,
+  -- * File reader with caching
+  freshStateFileReader,
   -- * Lookup operations
-  recipeFile, getAppState,
+  getFile, getAppState,
   -- * Identifiers for states
-  StateID, initialStateID
+  StateID, initialStateID,
+  -- * Server state/cache management
+  pinAppState, unpinAppState,
+  clearPersistentCache, setEphemeralCacheLimit,
+  ephemeralCacheMembers, persistentCacheMembers
   ) where
 
 import Control.Lens
+import Control.Monad (forM_)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as B
 import Data.Hashable (Hashable(..))
 import Data.HashMap.Strict (HashMap)
+import Data.List (sortOn)
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Data.Time.Clock (UTCTime, getCurrentTime)
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Aeson as JSON
 import Data.IORef
@@ -73,31 +82,60 @@ instance JSON.FromJSON StateID where
 
 newtype FileHash = FileHash ByteString deriving (Eq, Ord, Show, Hashable)
 
--- | Given a recipe step and its resulting application state, save
--- them to the cache and return a fresh state ID that describes the
--- resulting state.
-saveNewState ::
-  HasCallStack =>
-  ServerState recipeStep s ->
-  StateID {-^ The parent state -} ->
-  recipeStep {-^ The step taken to achieve the new state -} ->
-  s {-^ The new application state -} ->
+-- | Given a fresh application state, save it to the (ephemeral)
+--   cache and return a fresh state ID that uniquely describes the
+--   resulting state.
+saveNewAppState ::
+  ServerState appState ->
+  appState {-^ The new application state -} ->
   IO StateID
-saveNewState server parent step appState =
+saveNewAppState server newAppState =
   do uuid <- UUID.nextRandom
-     validateStateID parent
-     modifyIORef' (view stateRecipes server) $ set (at uuid) (Just (step, parent))
-     let sid = StateID uuid
-     modifyIORef' (view appStateCache server) $ set (at sid) (Just appState)
-     return sid
-  where
-    validateStateID :: HasCallStack => StateID -> IO ()
-    validateStateID InitialStateID = pure ()
-    validateStateID (StateID uuid) =
-      do recipes <- readIORef (view stateRecipes server)
-         case view (at uuid) recipes of
-           Nothing -> panic "saveNewState" ["Parent state ID not found"]
-           Just _ -> pure ()
+     now <- getCurrentTime
+     let cas = CachedAppState
+               { casState = newAppState
+               , casFiles = HM.empty
+               , casLastUsed = now
+               }
+     enforceCacheLimit server
+     modifyIORef' (view ephemeralStateCache server) $ HM.insert uuid cas
+     return $ StateID uuid
+
+
+-- If we are at or over capacity, remove the oldest item(s)
+-- from the ephemeral cache until we are at half capacity.
+enforceCacheLimit :: ServerState s -> IO ()
+enforceCacheLimit server = do
+  maxSize <- readIORef (view ephemeralStateCacheLimit server)
+  curSize <- HM.size <$> readIORef (view ephemeralStateCache server)
+  if (curSize >= maxSize) then do
+    entries <- HM.toList <$> readIORef (view ephemeralStateCache server)
+    -- Remove at least one, remove enough to get under max size, and
+    -- remove some extra to keep us under the cap for a bit if possible.
+    let n = max 1 $ max (curSize - maxSize) (maxSize `div` 2)
+    let extras = take n $ sortOn (casLastUsed . snd) entries
+    forM_ extras $ \(uuid, cas) -> do
+      -- Remove the state from the ephemeral cache.
+      modifyIORef' (view ephemeralStateCache server) $ HM.delete uuid
+      -- Decrement the reference tracking sets for the cached files.
+      mapM_ (removeRefToFile uuid) $ casFiles cas
+  else pure ()
+
+ where
+    -- Update the cached file corresponding to @fHash@ so it no longer thinks it
+    -- is referred to by @uuid@.
+    removeRefToFile :: UUID -> FileHash -> IO ()
+    removeRefToFile uuid fHash = do
+      (HM.lookup fHash <$> (readIORef (view cachedFiles server))) >>=
+        \case
+          Nothing -> pure ()
+          Just cf -> do
+            let states = Set.delete (StateID uuid) (cfStates cf)
+            if Set.null states
+            then modifyIORef' (view cachedFiles server) $ HM.delete fHash
+            else modifyIORef' (view cachedFiles server) $ HM.insert fHash (cf {cfStates = states})
+
+
 
 -- | Read a file and its hash simultaneously
 readWithHash :: FilePath -> IO (ByteString, FileHash)
@@ -106,142 +144,360 @@ readWithHash file =
      let fileHash = FileHash $! SHA1.hash contents
      return (contents, fileHash)
 
--- | A file reading operation that should be used when a state is
--- fresh; that is, when a state is being constructed for the first
--- time rather than when the client has sent its ID. This is intended
--- to be applied to its first two arguments by the server, and
+-- | A file reading operation that should be used to read a file
+-- for the first time for a state (i.e., when the state is
+-- fresh and is being constructed for the first time rather than
+-- when the client has sent its ID). This is intended to be 
+-- applied to its first two arguments by the server, and
 -- supplied to an app as a @FilePath -> IO ByteString@.
-freshStateReader ::
-  ServerState recipeStep s -> StateID -> FilePath -> IO ByteString
-freshStateReader server sid fileName =
-  do (contents, fileHash) <- readWithHash fileName
-     modifyIORef' (view stateFiles server) $ HM.insert (sid, fileName) fileHash
-     modifyIORef' (view stateFileContents server) $ HM.insert fileHash contents
-     return contents
+freshStateFileReader ::
+  ServerState s -> StateID -> FilePath -> IO ByteString
+freshStateFileReader server sid fileName = do
+  let cFilesRef = view cachedFiles server
+  (contents, fileHash) <- readWithHash fileName
+  -- Update the cached files map as appropriate.
+  (HM.lookup fileHash <$> (readIORef cFilesRef)) >>=
+    \case
+      Just _ -> do
+        -- We have _already_ seen this file before! Add this `sid` to the set
+        -- of states which refer to this file.
+        let updateCF = \cf -> cf {cfStates = Set.insert sid (cfStates cf)}
+        modifyIORef' cFilesRef $ HM.adjust updateCF fileHash
+      Nothing -> do
+        -- We have _not_ seen this file before. Add it to the cached files.
+        modifyIORef' cFilesRef $ 
+          HM.insert fileHash (CachedFile contents (Set.singleton sid))
+  -- Find and update the cached app state.
+  case sid of
+    InitialStateID -> do
+      modifyIORef' (view cachedInitState server) $ 
+        \cas -> cas {casFiles = HM.insert fileName fileHash (casFiles cas)}
+    StateID uuid -> do
+      (cas, casCacheRef) <- do
+        (HM.lookup uuid <$> readIORef (view ephemeralStateCache server)) >>=
+         \case
+           Just cas -> pure (cas, (view ephemeralStateCache server))
+           Nothing -> do
+             (HM.lookup uuid <$> readIORef (view persistentStateCache server)) >>=
+              \case
+                Just cas -> pure (cas, (view persistentStateCache server))
+                Nothing -> panic "readAndCacheFileForState" ["State ID not found: " ++ (show uuid)]
+      let cas' = cas {casFiles = HM.insert fileName fileHash (casFiles cas)}
+      modifyIORef' casCacheRef $ HM.insert uuid cas'
+  pure contents
 
--- | Server states contain cached application states and manage state
--- identifiers. They are intended to be guarded by an 'MVar' to
--- prevent the 'IORef's from being mutated inconsistently.
-data ServerState recipeStep s =
-  ServerState
-  { _initialAppState :: !s
-    -- ^ The application state that corresponds to the empty recipe
-  , _stateRecipes :: !(IORef (HashMap UUID (recipeStep, StateID)))
-    -- ^ A mapping from non-initial state IDs to recipes that can be
-    -- used to reconstruct them. Here, a recipe consists of the
-    -- parent's state ID and the step that was taken to arrive at the
-    -- present state.
-  , _stateFiles :: !(IORef (HashMap (StateID, FilePath) FileHash))
-    -- ^ A mapping from complete recipes to the relevant state of the
-    -- filesystem at the time of their initial execution. We expect
-    -- files to be much smaller than application states in practice,
-    -- so we can reconstruct application states on demand.
-  , _stateFileContents :: !(IORef (HashMap FileHash ByteString))
-    -- ^ De-duplicated file contents (see '_stateFiles').
-  , _appStateCache :: !(IORef (HashMap StateID s))
-    -- ^ Some saved application states - this is essentially a partial
-    -- memo table for the interpreter that can reconstruct states.
+
+data CachedFile =
+  CachedFile
+  { cfContents :: !ByteString
+  -- ^ File Contents
+  , cfStates :: !(Set StateID)
+    -- ^ States referring to this file.
   }
 
+data CachedAppState s =
+  CachedAppState
+  { casState :: !s
+  -- ^ The cached app state itself.  
+  , casFiles :: !(HashMap FilePath FileHash)
+  -- ^ Files this state relies on.
+  , casLastUsed :: !UTCTime
+  -- ^ When this state last involved in a server request.
+  }
+
+-- | Options affecting how the server initial settings at launch.
+data ServerOpts =
+  ServerOpts
+  {
+    initEphemeralStateCacheLimit :: !Int
+  }
+
+-- | Generic server options, including the following:
+--   * Ephemeral cache size (see @optEphemeralCacheLimit@, default is @10@.)
+defaultServerOpts :: ServerOpts
+defaultServerOpts =
+  ServerOpts
+  {
+    initEphemeralStateCacheLimit = 10
+  }
+
+-- | Updates the size of the ephemeral state cache for a @ServerOpts@,
+-- i.e., how many non-pinned, non-initial states are kept alive by
+-- the server. When the limit is reached, half of the ephemeral states
+-- (the oldest) are purged from the cache and are no longer available
+-- for server requests.
+optEphemeralCacheLimit ::
+  Int ->
+  ServerOpts ->
+  ServerOpts
+optEphemeralCacheLimit sz opts =
+  opts {
+          initEphemeralStateCacheLimit = sz
+       }
+
+
+-- | @ServerState@s contain cached application states and manage state
+-- identifiers. They are intended to be guarded by an 'MVar' to
+-- prevent the 'IORef's from being mutated inconsistently.
+data ServerState appState =
+  ServerState
+  { _cachedInitState :: !(IORef (CachedAppState appState))
+  -- State entered when server is started (is retained indefinitely).
+  , _cachedFiles :: !(IORef (HashMap FileHash CachedFile))
+    -- ^ Cache of loaded files (allows for sharing and tracking usage).
+    --   N.B., cached files should be updated and possibly purged by Argo
+    --   as states that refer to them are purged (see @cachedFileStates@
+    --   field of @CachedFile@).
+  , _ephemeralStateCache :: !(IORef (HashMap UUID (CachedAppState appState)))
+    -- ^ Live application states which are subject to being purged.
+  , _persistentStateCache :: !(IORef (HashMap UUID (CachedAppState appState)))
+    -- ^ Live application states which are retained until otherwise directed.
+  , _ephemeralStateCacheLimit :: !(IORef Int)
+  -- ^ Maximum number of application states to keep live in the ephemeral cache.
+  }
+
+-- | A lens into the cached initial server state
+cachedInitState :: Lens' (ServerState appState) (IORef (CachedAppState appState))
+cachedInitState = lens _cachedInitState (\s is -> s { _cachedInitState = is })
+
+-- | A lens into the cache of files used by in-cache states.
+cachedFiles :: Lens' (ServerState appState) (IORef (HashMap FileHash CachedFile))
+cachedFiles = lens _cachedFiles (\s fs -> s { _cachedFiles = fs })
+
+-- | A lens into the server's ephemoral cached application states.
+ephemeralStateCache :: Lens' (ServerState appState) (IORef (HashMap UUID (CachedAppState appState)))
+ephemeralStateCache = lens _ephemeralStateCache (\s c -> s { _ephemeralStateCache = c })
+
+
+-- | A lens into the server's persistent cached application states.
+persistentStateCache :: Lens' (ServerState appState) (IORef (HashMap UUID (CachedAppState appState)))
+persistentStateCache = lens _persistentStateCache (\s c -> s { _persistentStateCache = c })
+
+-- | A lens to the maximum number of states to keep in cache (if one exists).
+ephemeralStateCacheLimit :: Lens' (ServerState appState) (IORef Int)
+ephemeralStateCacheLimit = lens _ephemeralStateCacheLimit (\s sz -> s { _ephemeralStateCacheLimit = sz })
+
+
 -- | Construct an initial server state, given a means of constructing
--- the initial application state.
+-- the initial application state and a bound on the number of states 
+-- to keep cached.
 --
 -- The initial application state is associated with the empty recipe
 -- @[]@ and the initial 'StateID'.
-initialState ::
-  ((FilePath -> IO ByteString) -> IO s) ->
-  IO (ServerState recipeStep s)
-initialState mkS =
-  do recs <- newIORef $ HM.empty
-     files <- newIORef HM.empty
-     fileContents <- newIORef HM.empty
-     s <- mkS $ initFileReader files fileContents
-     initCache <- newIORef $ HM.fromList [(initialStateID, s)]
+initServerState ::
+  ServerOpts ->
+  ((FilePath -> IO ByteString) -> IO appState) ->
+  IO (ServerState appState)
+initServerState opts mkInitState =
+  do fileCache <- newIORef HM.empty
+     eStateCache <- newIORef $ HM.empty
+     pStateCache <- newIORef $ HM.empty
+     eLimit <- newIORef (initEphemeralStateCacheLimit opts)
+     initStateFiles <- newIORef $ HM.empty
+     s <- mkInitState $ initFileReader fileCache initStateFiles
+     sFiles <- readIORef initStateFiles
+     now <- getCurrentTime
+     cInitState <- newIORef $ CachedAppState s sFiles now
      pure $
        ServerState
-       {  _initialAppState = s
-       , _stateRecipes = recs
-       , _stateFiles = files
-       , _stateFileContents = fileContents
-       , _appStateCache = initCache
+       { _cachedInitState = cInitState
+       , _cachedFiles = fileCache
+       , _ephemeralStateCache = eStateCache
+       , _persistentStateCache = pStateCache
+       , _ephemeralStateCacheLimit = eLimit
        }
   where
-    initFileReader files fileContents path =
+    initFileReader :: IORef (HashMap FileHash CachedFile) -> 
+                      IORef (HashMap FilePath FileHash) ->
+                      FilePath ->
+                      IO ByteString
+    initFileReader fileCache initStateFiles path =
       do (contents, fileHash) <- readWithHash path
-         modifyIORef' files $ HM.insert (initialStateID, path) fileHash
-         modifyIORef' fileContents $ HM.insert fileHash contents
-         return contents
+         modifyIORef' fileCache $ HM.insert fileHash (CachedFile contents (Set.singleton initialStateID))
+         (HM.lookup path <$> readIORef initStateFiles) >>=
+          \case
+            -- We haven't seen this file before during initial state creation, so just add it
+            -- and it's content to the hash maps.
+            Nothing -> do
+              modifyIORef' initStateFiles $ HM.insert path fileHash
+            -- They read the same file twice while creating the initial state and the contents
+            -- did not change... do nothing since we've already cached the contents.
+            Just prevHash | prevHash == fileHash -> pure ()
+            -- They've re-read this file but the contents are now different. Remove the old cached
+            -- contents (since we identify files uniquely by state and filepath) and log
+            -- the new one..
+            Just prevHash -> do
+              modifyIORef' fileCache $ HM.delete prevHash
+              modifyIORef' initStateFiles $ HM.insert path fileHash
+         pure contents
 
-initialAppState :: Lens' (ServerState recipeStep s) s
-initialAppState = lens _initialAppState (\s a -> s { _initialAppState = a })
 
-stateRecipes :: Lens' (ServerState recipeStep s) (IORef (HashMap UUID (recipeStep, StateID)))
-stateRecipes = lens _stateRecipes (\s r -> s { _stateRecipes = r })
+-- | Lookup a @CachedAppState@ (whether it's cached ephemerally or
+--   persistently) and update it's last used timestamp.
+getCachedAppState :: 
+  ServerState s ->
+  StateID ->
+  IO (Maybe (CachedAppState s))
+getCachedAppState server InitialStateID = do
+  s <- readIORef $ view cachedInitState server
+  pure $ Just s
+getCachedAppState server (StateID uuid) = do
+  (HM.lookup uuid <$> (readIORef $ view ephemeralStateCache server)) >>=
+    \case
+      Just cas -> do
+        now <- getCurrentTime
+        modifyIORef' (view ephemeralStateCache server) $ HM.insert uuid (cas {casLastUsed = now})
+        pure $ Just cas
+      Nothing -> do
+        (HM.lookup uuid <$> (readIORef $ view persistentStateCache server)) >>=
+          \case
+            Just cas -> do
+              now <- getCurrentTime
+              modifyIORef' (view persistentStateCache server) $ HM.insert uuid (cas {casLastUsed = now})
+              pure $ Just cas
+            Nothing -> pure Nothing
 
--- | A lens into the server's cache of application states. It is save
--- to remove entries from this cache.
-appStateCache :: Lens' (ServerState recipeStep s) (IORef (HashMap StateID s))
-appStateCache = lens _appStateCache (\s c -> s { _appStateCache = c })
-
-stateFiles :: Lens' (ServerState recipeStep s) (IORef (HashMap (StateID, FilePath) FileHash))
-stateFiles = lens _stateFiles (\s fs -> s { _stateFiles = fs })
-
-stateFileContents :: Lens' (ServerState recipeStep s) (IORef (HashMap FileHash ByteString))
-stateFileContents = lens _stateFileContents (\s fc -> s { _stateFileContents = fc })
 
 -- | Retrieve the contents of a file as they were in a particular state.
-recipeFile ::
-  ServerState recipeStep s ->
+getFile ::
+  ServerState appState ->
   StateID ->
   FilePath -> IO ByteString
-recipeFile server sid filename =
-  do hashes <- readIORef $ view stateFiles server
-     theHash <-
-       case view (at (sid, filename)) hashes of
-         Nothing ->
-           ioError $
-           IOError { ioe_handle = Nothing
-                   , ioe_type = NoSuchThing
-                   , ioe_location = "restoring " ++ filename
-                   , ioe_description = "No such cached file " ++ filename
-                   , ioe_errno = Nothing
-                   , ioe_filename = Just filename
-                   }
-         Just h -> pure h
-     fileContents <- readIORef $ view stateFileContents server
-     case view (at theHash) fileContents of
-       Nothing ->
-         ioError $
+getFile server sid filename = do
+  sFiles <- getCachedAppState server sid >>=
+              \case
+                 Nothing -> raiseNoSuchState
+                 Just cState -> pure $ casFiles cState
+  fHash <- case HM.lookup filename sFiles of
+             Nothing -> raiseNoSuchFile
+             Just fileHash -> pure fileHash
+  (HM.lookup fHash <$> readIORef (view cachedFiles server)) >>=
+    \case
+       Nothing -> raiseNoSuchFile
+       Just cf -> pure $ cfContents cf
+  where
+      raiseNoSuchFile =
+        ioError $
          IOError { ioe_handle = Nothing
                  , ioe_type = NoSuchThing
                  , ioe_location = "restoring " ++ filename
-                 , ioe_description = "No contents for cached file " ++ filename
+                 , ioe_description = "No such cached file " ++ filename
                  , ioe_errno = Nothing
                  , ioe_filename = Just filename
                  }
-       Just bs -> pure bs
+      raiseNoSuchState =
+        ioError $
+         IOError { ioe_handle = Nothing
+                 , ioe_type = NoSuchThing
+                 , ioe_location = "restoring " ++ filename ++ " in state " ++ (show sid)
+                 , ioe_description = "No such state currently cached " ++ (show sid)
+                 , ioe_errno = Nothing
+                 , ioe_filename = Just filename
+                 }
+
 
 
 -- | Retrieve the application state that corresponds to a given state ID.
 --
 -- If the state ID is not known, returns Nothing.
 getAppState ::
-  (HasCallStack, Eq recipeStep, Hashable recipeStep) =>
-  (s -> recipeStep -> (FilePath -> IO ByteString) -> IO s) {- ^ How to take one step of the recipe -} ->
-  ServerState recipeStep s ->
+  ServerState appState ->
   StateID ->
-  IO (Maybe s)
-getAppState _ server InitialStateID = pure $ Just $ view initialAppState server
-getAppState runStep server sid@(StateID uuid) =
-     -- First check whether the state itself is cached. If so, return it.
-  do caches <- readIORef $ view appStateCache server
-     case view (at sid) caches of
-       Just s -> return $ Just s
-       Nothing ->
-         -- If it is not cached, then reconstruct it by playing back history.
-         do recipes <- readIORef $ view stateRecipes server
-            case view (at uuid) recipes of
-              Nothing -> return Nothing
-              Just (step, parent) ->
-                do s <- getAppState runStep server parent
-                   traverse (\s' -> runStep s' step (recipeFile server parent)) s
+  IO (Maybe appState)
+getAppState server sid = do
+  mCAS <- getCachedAppState server sid
+  pure $ casState <$> mCAS
+
+
+-- | Ensure a currently visible state remains visible/in-cache
+-- until explicitly unpinned.
+pinAppState ::
+  ServerState appState ->
+  StateID ->
+  IO ()
+pinAppState _server InitialStateID = pure ()
+pinAppState server (StateID uuid) =
+  (HM.lookup uuid <$> readIORef (view ephemeralStateCache server)) >>=
+    \case
+      Just cas -> do
+        -- Move it from the ephemeral to the persistent cache.
+        now <- getCurrentTime
+        modifyIORef' (view ephemeralStateCache server) $ HM.delete uuid
+        modifyIORef' (view persistentStateCache server) $ HM.insert uuid (cas {casLastUsed = now})
+      Nothing -> do
+        -- We didn't see it in the ephemeral cache... let's see if it's already in the persistent cache.
+        (HM.lookup uuid <$> readIORef (view persistentStateCache server)) >>=
+          \case
+            Just cas -> do
+              -- Let's just update the last used time.
+              now <- getCurrentTime
+              modifyIORef' (view persistentStateCache server) $ HM.insert uuid (cas {casLastUsed = now})
+            Nothing -> do
+              -- We didn't see it in either cache... uh oh
+              ioError $
+                IOError { ioe_handle = Nothing
+                        , ioe_type = NoSuchThing
+                        , ioe_location = "pinning state " ++ (show uuid)
+                        , ioe_description = "No such state currently cached " ++ (show uuid)
+                        , ioe_errno = Nothing
+                        , ioe_filename = Nothing
+                        }
+
+
+-- Like unpinAppState but takes a UUID and performs no cache flushing.
+internalUnpinAppState ::
+  ServerState appState ->
+  UUID ->
+  IO ()
+internalUnpinAppState server uuid =
+  (HM.lookup uuid <$> readIORef (view persistentStateCache server)) >>=
+    \case
+      Just cas -> do
+        modifyIORef' (view ephemeralStateCache server) $ HM.insert uuid cas
+        modifyIORef' (view persistentStateCache server) $ HM.delete uuid
+      Nothing -> pure ()
+
+
+-- | Unpin a cached state (a noop if the state is not found in the persistent cache).
+unpinAppState ::
+  ServerState appState ->
+  StateID ->
+  IO ()
+unpinAppState _server InitialStateID = pure ()
+unpinAppState server (StateID uuid) = do
+  internalUnpinAppState server uuid
+  enforceCacheLimit server
+
+-- | Move states from the persistent cache into the ephemeral cache
+-- and empty old states from the cache if necessary.
+clearPersistentCache ::
+  ServerState appState ->
+  IO ()
+clearPersistentCache server = do
+  pids <- HM.keys <$> readIORef (view persistentStateCache server)
+  mapM_ (internalUnpinAppState server) pids
+  enforceCacheLimit server
+
+-- | Change the ephemeral cache limit and clean the cache to meet
+-- the new limit if necessary.
+setEphemeralCacheLimit ::
+  ServerState appState ->
+  Int ->
+  IO ()
+setEphemeralCacheLimit server sz = do
+  writeIORef (view ephemeralStateCacheLimit server) (max sz 1)
+  enforceCacheLimit server
+
+-- | Return the keys in the ephemeral cache.
+ephemeralCacheMembers ::
+  ServerState appState ->
+  IO [UUID]
+ephemeralCacheMembers server =
+  HM.keys <$> readIORef (view ephemeralStateCache server)
+
+-- | Return the keys in the persistent cache.
+persistentCacheMembers ::
+  ServerState appState ->
+  IO [UUID]
+persistentCacheMembers server =
+  HM.keys <$> readIORef (view persistentStateCache server)

--- a/argo/src/Argo/Socket.hs
+++ b/argo/src/Argo/Socket.hs
@@ -8,8 +8,8 @@ import Control.Concurrent       (forkFinally)
 import Control.Concurrent.Async (Async, async, forConcurrently_)
 import Control.Exception        (displayException)
 import Control.Monad            (forever)
-import Data.Text                (Text, pack)
-import System.IO                (IOMode(ReadWriteMode), hClose, stderr)
+import qualified Data.Text as T
+import System.IO                (IOMode(ReadWriteMode), hClose)
 
 import qualified Network.Socket as N
 
@@ -92,11 +92,11 @@ acceptClient opts app s =
      let logMessage = optLogger opts
      -- don't use c after this, it is owned by h
 
-     logMessage (pack ("CONNECT: " ++ show peer))
+     logMessage (T.pack ("CONNECT: " ++ show peer))
      _ <- forkFinally (serveHandlesNS opts h h app) $ \res ->
        do case res of
-            Right _ -> logMessage (pack ("CLOSE: " ++ show peer))
-            Left e  -> logMessage (pack ("ERROR: " ++ show peer ++ " " ++ displayException e))
+            Right _ -> logMessage (T.pack ("CLOSE: " ++ show peer))
+            Left e  -> logMessage (T.pack ("ERROR: " ++ show peer ++ " " ++ displayException e))
           hClose h
 
      return ()

--- a/file-echo-api/README.rst
+++ b/file-echo-api/README.rst
@@ -1,53 +1,207 @@
-``file-echo-api``
-=================
+file-echo-api
+=============
 
-A simple example usage of Argo: a JSON-RPC "file echo server" which can load files on disk and send their contents back to the client.
+Fundamental Protocol
+--------------------
 
-Commands
---------------------------
+This application is a `JSON-RPC <https://www.jsonrpc.org/specification>`_ server. Additionally, it maintains a persistent cache of application states and explicitly indicates the state in which each command is to be carried out.
 
-* ``load``
+Transport
+~~~~~~~~~
 
-  * Loads a file into the echo server's memory.  
-  * Parameters
+The server supports three transport methods:
 
-    * ``file path : String``
+
+``stdio``
+  in which the server communicates over``stdin``and``stdout``
   
-      * File path describing which file to load.
-
-* ``clear``
   
-  * Clears any loaded file from the server's memory.
-  * No parameters
 
-* ``implode``
+Socket
+  in which the server communicates over``stdin``and``stdout``
   
-  * Causes the server to raise an internal error (for testing purposes).
-  * No parameters
-
-Queries
--------------------------
-
-* ``show``
   
-  * Returns the contents of the last loaded file.
 
-  * No required parameters
-  * Optional parameters
-
-    * ``start : Integer``
+HTTP
+  in which the server communicates over HTTP
   
-      * Character index in loaded file to begin showing from, default value ``0``.
   
-    * ``end : Integer``
+In both``stdio``and socket mode, messages are delimited using `netstrings. <http://cr.yp.to/proto/netstrings.txt>`_
+
+
+Application State
+~~~~~~~~~~~~~~~~~
+
+According to the JSON-RPC specification, the ``params`` field in a message object must be an array or object. In this protocol, it is always an object. While each message may specify its own arguments, every message has a parameter field named ``state``.
+
+When the first message is sent from the client to the server, the ``state`` parameter should be initialized to the JSON null value ``null``. Replies from the server may contain a new state that should be used in subsequent requests, so that state changes executed by the request are visible. Prior versions of this protocol represented the initial state as the empty array ``[]``, but this is now deprecated and will be removed.
+
+In particular, per JSON-RPC, non-error replies are always a JSON object that contains a ``result`` field. The result field always contains an ``answer`` field and a ``state`` field, as well as ``stdout`` and ``stderr``.
+
+
+``answer``
+  The value returned as a response to the request (the precise contents depend on which request was sent)
   
-      * Character index to show up until (but not including), default value is the character length of the currently loaded file minus the ``start`` parameter's value.
+  
+
+``state``
+  The state, to be sent in subsequent requests. If the server did not modify its state in response to the command, then this state may be the same as the one sent by the client.
+  
+  
+
+``stdout`` and ``stderr``
+  These fields contain the contents of the Unix ``stdout`` and ``stderr`` file descriptors. They are intended as a stopgap measure for clients who are still in the process of obtaining structured information from the libraries on which they depend, so that information is not completely lost to users. However, the server may or may not cache this information and resend it. Applications are encouraged to used structured data and send it deliberately as the answer.
+  
+  
+The precise structure of states is considered an implementation detail that could change at any time. Please treat them as opaque tokens that may be saved and re-used within a given server process, but not created by the client directly.
 
 
-Files
------
 
-* ``src/FileEchoServer.hs`` implements the internals of the server.
-* ``file-echo-api/Main.hs`` defines an Argo executable leveraging the definitions from ``FileEchoServer.hs``.
-* ``test/Test.hs`` a Haskell test runner which executes the python script ``file-echo-tests.py``.
-* ``test-scripts/file-echo-tests.py`` is a python script which leverages the ``argo`` python library to test the file echo server.
+A sample server that demonstrates filesystem caching.
+
+Datatypes
+---------
+
+.. _Ignorable:
+Ignorable data
+~~~~~~~~~~~~~~
+
+Data to be ignored can take one of three forms:
+
+
+``true``
+  The first ignorable value
+  
+  
+
+``false``
+  The second ignorable value
+  
+  
+
+``null``
+  The ultimate ignorable value, neither true nor false
+  
+  
+Nothing else may be ignored.
+
+
+
+Methods
+-------
+
+load (command)
+~~~~~~~~~~~~~~
+
+
+``file path``
+  The file to read into memory.
+  
+  
+Load a file from disk into memory.
+
+
+clear (command)
+~~~~~~~~~~~~~~~
+
+No parameters
+
+Forget the loaded file.
+
+
+prepend (command)
+~~~~~~~~~~~~~~~~~
+
+
+``content``
+  The string to append to the left of the current file content on the server.
+  
+  
+Append a string to the left of the current contents.
+
+
+drop (command)
+~~~~~~~~~~~~~~
+
+
+``count``
+  The number of characters to drop from the left of the current file content on the server.
+  
+  
+Drop from the left of the current contents.
+
+
+implode (query)
+~~~~~~~~~~~~~~~
+
+No parameters
+
+Throw an error immediately.
+
+
+show (query)
+~~~~~~~~~~~~
+
+
+``start``
+  Start index (inclusive). If not provided, the substring is from the beginning of the file.
+  
+  
+
+``end``
+  End index (exclusive). If not provided, the remainder of the file is returned.
+  
+  
+Show a substring of the file.
+
+
+ignore (query)
+~~~~~~~~~~~~~~
+
+
+``to be ignored``
+  The value to be ignored goes here.
+  
+  
+Ignore an :ref:`ignorable value <Ignorable>`.
+
+
+pin state (notification)
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+``state to pin``
+  The state to pin in the server so it is available until unpinned.
+  
+  
+Pins a state in the server so it is available until unpinned.
+
+
+unpin state (notification)
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+``state to unpin``
+  The state to unpin in the server (so it can be released from memory).
+  
+  
+Unpins a state in the server.
+
+
+unpin all states (notification)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+No parameters
+
+Unpin all states in the server.
+
+
+set cache limit (notification)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+``cache limit``
+  Limit how many temporarily cached states can accumulate.
+  
+  
+Unpin all states in the server.

--- a/file-echo-api/file-echo-api/Main.hs
+++ b/file-echo-api/file-echo-api/Main.hs
@@ -18,7 +18,7 @@ main :: IO ()
 main = customMain parseServerOptions parseServerOptions parseServerOptions parseServerOptions description getApp
   where
     getApp opts =
-      Argo.mkApp "file-echo-api" docs (mkInitState $ userOptions opts) serverMethods
+      Argo.mkDefaultApp "file-echo-api" docs (mkInitState $ userOptions opts) serverMethods
 
 docs :: [Doc.Block]
 docs =
@@ -51,7 +51,13 @@ serverMethods :: [Argo.AppMethod FES.ServerState]
 serverMethods =
   [ Argo.method "load" Argo.Command (Doc.Paragraph [Doc.Text "Load a file from disk into memory."]) FES.loadCmd
   , Argo.method "clear" Argo.Command (Doc.Paragraph [Doc.Text "Forget the loaded file."]) FES.clearCmd
+  , Argo.method "prepend" Argo.Command (Doc.Paragraph [Doc.Text "Append a string to the left of the current contents."]) FES.prependCmd
+  , Argo.method "drop" Argo.Command (Doc.Paragraph [Doc.Text "Drop from the left of the current contents."]) FES.dropCmd
   , Argo.method "implode" Argo.Query (Doc.Paragraph [Doc.Text "Throw an error immediately."]) FES.implodeCmd
   , Argo.method "show" Argo.Query (Doc.Paragraph [Doc.Text "Show a substring of the file."]) FES.showCmd
   , Argo.method "ignore" Argo.Query (Doc.Paragraph [Doc.Text "Ignore an ", Doc.Link (Doc.TypeDesc (typeRep (Proxy @FES.Ignorable))) "ignorable value", Doc.Text "."]) FES.ignoreCmd
+  , Argo.method "pin state" Argo.Notification (Doc.Paragraph [Doc.Text "Pins a state in the server so it is available until unpinned."]) FES.pinState
+  , Argo.method "unpin state" Argo.Notification (Doc.Paragraph [Doc.Text "Unpins a state in the server."]) FES.unpinState
+  , Argo.method "unpin all states" Argo.Notification (Doc.Paragraph [Doc.Text "Unpin all states in the server."]) FES.unpinAllStates
+  , Argo.method "set cache limit" Argo.Notification (Doc.Paragraph [Doc.Text "Unpin all states in the server."]) FES.setCacheLimit
   ]

--- a/file-echo-api/test-scripts/file-echo-tests.py
+++ b/file-echo-api/test-scripts/file-echo-tests.py
@@ -6,6 +6,8 @@ import subprocess
 import sys
 import time
 import json
+import unittest
+import atexit
 
 import argo.connection as argo
 
@@ -17,114 +19,8 @@ if not file_dir.is_dir():
     print('ERROR: ' + str(file_dir) + ' is not a directory!')
     assert(False)
 
-
-def run_tests(c):
-    ## Positive tests -- make sure the server behaves as we expect with valid RPCs
-
-    # Check that their is nothing to show if we haven't loaded a file yet
-    uid = c.send_message("show", {"state": None})
-    actual = c.wait_for_reply_to(uid)
-    expected = {'result':{'state':None,'stdout':'','stderr':'','answer':{'value':''}},'jsonrpc':'2.0','id':uid}
-    assert(actual == expected)
-    prev_uid = uid
-
-    # load a file
-    hello_file = file_dir.joinpath('hello.txt')
-    assert(False if not hello_file.is_file() else True)
-    uid = c.send_message("load", {"file path": str(hello_file), "state": None})
-    actual = c.wait_for_reply_to(uid)
-    assert('result' in actual and 'state' in actual['result'])
-    hello_state = actual['result']['state']
-    expected = {'result':{'state':hello_state,'stdout':'','stderr':'','answer':[]},'jsonrpc':'2.0','id':uid}
-    assert(actual == expected)
-    assert(uid != prev_uid)
-    assert(hello_state != None)
-    prev_uid = uid
-
-    # check the contents of the loaded file
-    uid = c.send_message("show", {"state": hello_state})
-    actual = c.wait_for_reply_to(uid)
-    expected = {'result':{'state':hello_state,'stdout':'','stderr':'','answer':{'value':'Hello World!\n'}},'jsonrpc':'2.0','id':uid}
-    assert(actual == expected)
-    assert(uid != prev_uid)
-    prev_uid = uid
-
-    # check a _portion_ of the contents of the loaded file
-    uid = c.send_message("show", {"start":1, "end":5, "state": hello_state})
-    actual = c.wait_for_reply_to(uid)
-    expected = {'result':{'state':hello_state,'stdout':'','stderr':'','answer':{'value':'ello'}},'jsonrpc':'2.0','id':uid}
-    assert(actual == expected)
-    assert(uid != prev_uid)
-    prev_uid = uid
-
-    # clear the loaded file
-    uid = c.send_message("clear", {"state": hello_state})
-    actual = c.wait_for_reply_to(uid)
-    assert('result' in actual and 'state' in actual['result'])
-    cleared_state = actual['result']['state']
-    expected = {'result':{'state':cleared_state,'stdout':'','stderr':'','answer':[]},'jsonrpc':'2.0','id':uid}
-    assert(actual == expected)
-    assert(cleared_state != hello_state)
-    assert(uid != prev_uid)
-
-    # check that the file contents cleared
-    uid = c.send_message("show", {"state": cleared_state})
-    actual = c.wait_for_reply_to(uid)
-    expected = {'result':{'state':cleared_state,'stdout':'','stderr':'','answer':{'value':''}},'jsonrpc':'2.0','id':uid}
-    assert(actual == expected)
-
-    ## Negative tests -- make sure the server errors as we expect
-
-    # Method not found
-    uid = c.send_message("bad function", {"state": cleared_state})
-    actual = c.wait_for_reply_to(uid)
-    expected = {'error':{'data':{'stdout':None,'data':'bad function','stderr':None},'code':-32601,'message':'Method not found'},'jsonrpc':'2.0','id':uid}
-    assert(actual == expected)
-
-    # Invalid params
-    uid = c.send_message("load", {"file path": 12345, "state": cleared_state})
-    actual = c.wait_for_reply_to(uid)
-    expected = {'error':{'data':{'stdout':'','data':{'state':cleared_state,'file path':12345},'stderr':''},'code':-32602,'message':'Invalid params: expected String, but encountered Number'},'jsonrpc':'2.0','id':uid}
-    assert(actual == expected)
-
-    # load a nonexistent file, check error that is returned
-    nonexistent_file = file_dir.joinpath('nonexistent.txt')
-    if nonexistent_file.is_file():
-        print('ERROR: ' + str(nonexistent_file) + ' was expected to not exist, but it does!')
-        assert(False)
-    uid = c.send_message("load", {"file path": str(nonexistent_file), "state": cleared_state})
-    actual = c.wait_for_reply_to(uid)
-    expected = {'error':{'data':{'stdout':'','data':{'path':str(nonexistent_file)},'stderr':''},'code':20051,'message':'File doesn\'t exist: ' + str(nonexistent_file)},'jsonrpc':'2.0','id':uid}
-    assert(actual == expected)
-
-
-    # cause server to have an internal error
-    uid = c.send_message("implode", {"state": cleared_state})
-    actual = c.wait_for_reply_to(uid)
-    expected = {'error':{'data':{'stdout':'','stderr':''},'code':-32603,'message':'Internal error'},'jsonrpc':'2.0','id':uid}
-    assert(actual == expected)
-
-    # send a request with an invalid state id
-    uid = c.send_message("show", {"state": "12345678-9101-1121-3141-516171819202"})
-    actual = c.wait_for_reply_to(uid)
-    expected = {'error':{'data':{'stdout':None,'data':'12345678-9101-1121-3141-516171819202','stderr':None},'code':20,'message':'Unknown state ID'},'jsonrpc':'2.0','id':uid}
-    assert(actual == expected)
-
-    # invalid request (missing JSON-RPC required fields)
-    invalid_request = {'jsonrpc': '2.0','method': 'bad request', 'id':1}
-    c.process.send_one_message(json.dumps(invalid_request))
-    actual = c.wait_for_reply_to(None)
-    expected = {'error':{'data':{'stdout':None,'data':'Error in $: key \"params\" not found','stderr':None},'code':-32700,'message':'Parse error'},'jsonrpc':'2.0','id':None}
-    assert(actual == expected)
-
-   # invalid request (Bad JSON)
-    invalid_request = "BAAAAAD JSON"
-    c.process.send_one_message(invalid_request)
-    time.sleep(2) # pause before fetching response so we don't just read the previous response whose JSON-RPC id is `null`
-    actual = c.wait_for_reply_to(None)
-    expected = {'error':{'data':{'stdout':None,'data':'Error in $: Failed reading: not a valid json value at \'BAAAAADJSON\'','stderr':None},'code':-32700,'message':'Parse error'},'jsonrpc':'2.0','id':None}
-    assert(actual == expected)
-
+# Test the custom command line argument to load a file at server start
+hello_file = file_dir.joinpath('hello.txt')
 
 # Test with both sockets and stdio
 env = os.environ.copy()
@@ -147,72 +43,384 @@ p_http = subprocess.Popen(
            env=env)
 
 
+def kill_procs():
+    if p: p.kill()
+    if p_http: p_http.kill()
+
+atexit.register(kill_procs)
+
+
 time.sleep(5)
 assert(p is not None)
 assert(p.poll() is None)
 assert(p_http is not None)
 assert(p_http.poll() is None)
 
-# Test argo's RemoteSocketProcess
-c = argo.ServerConnection(
-       argo.RemoteSocketProcess('localhost', 50005, ipv6=True))
+# What the response to "show" looks like
+def show_res(*,content,uid,state):
+    r = {'result':{'state':state,'stdout':'','stderr':'','answer':{'value':content}},'jsonrpc':'2.0','id':uid}
+    return r
 
-run_tests(c)
+# What the response looks like when a state is not in cache/pinned on the server
+def bad_state_res(*,uid,state):
+    r = {'error':{'data':{'stdout':None,'data':state,'stderr':None},'code':20,'message':'Unknown state ID'},'jsonrpc':'2.0','id':uid}
+    return r
 
-# close the remote process, we don't need it for the remaining tests
-os.killpg(os.getpgid(p.pid), signal.SIGKILL)
-
-# Test argo's DynamicSocketProcess
-c = argo.ServerConnection(
-       argo.DynamicSocketProcess("cabal v2-exec file-echo-api --verbose=0 -- socket --port 50005"))
-
-run_tests(c)
-
-c = argo.ServerConnection(
-       argo.StdIOProcess("cabal v2-exec file-echo-api --verbose=0 -- stdio"))
-
-run_tests(c)
-
+# Helper to churn through states on the server
+def gen_misc_states(c, iterations):
+    state = None
+    for i in range (1,iterations):
+        # append "foo" on the left then remove it, over and over to churn through states
+        uid = c.send_command("prepend", {"content":"foo", "state": state})
+        state = c.wait_for_reply_to(uid)['result']['state']
+        uid = c.send_command("drop", {"count":3, "state": state})
+        state = c.wait_for_reply_to(uid)['result']['state']
 
 
-c_http = argo.ServerConnection(
-            argo.HttpProcess(url="http://localhost:8080/"))
+class GenericFileEchoTests():
 
-run_tests(c_http)
 
-### Additional tests for the HTTP server ###
+    # to be implemented by classes extending this one
+    def get_connection(self): pass
+    def get_caching_iterations(self): pass
 
-# Ensure that only POST is allowed to the designated URL
-get_response = requests.get("http://localhost:8080/")
-assert(get_response.status_code == 405)
+    def test_basics(self):
+        c = self.get_connection()
+        ## Positive tests -- make sure the server behaves as we expect with valid RPCs
 
-# Ensure that other URLs give 404
-get_response = requests.get("http://localhost:8080/some/other/resource")
-assert(get_response.status_code == 404)
+        # Check that their is nothing to show if we haven't loaded a file yet
+        uid = c.send_query("show", {"state": None})
+        actual = c.wait_for_reply_to(uid)
+        expected = show_res(content='',uid=uid,state=None)
+        self.assertEqual(actual, expected)
+        prev_uid = uid
 
-post_response = requests.post("http://localhost:8080/some/other/resource")
-assert(post_response.status_code == 404)
+        # load a file
+        hello_file = file_dir.joinpath('hello.txt')
+        self.assertTrue(False if not hello_file.is_file() else True)
+        uid = c.send_command("load", {"file path": str(hello_file), "state": None})
+        actual = c.wait_for_reply_to(uid)
+        self.assertTrue('result' in actual and 'state' in actual['result'])
+        hello_state = actual['result']['state']
+        expected = {'result':{'state':hello_state,'stdout':'','stderr':'','answer':[]},'jsonrpc':'2.0','id':uid}
+        self.assertEqual(actual, expected)
+        self.assertNotEqual(uid, prev_uid)
+        self.assertNotEqual(hello_state, None)
+        prev_uid = uid
 
-# Wrong content-type
-post_response = requests.post("http://localhost:8080/")
-assert(post_response.status_code == 415)
+        # check the contents of the loaded file
+        uid = c.send_query("show", {"state": hello_state})
+        actual = c.wait_for_reply_to(uid)
+        expected = show_res(content='Hello World!\n',uid=uid,state=hello_state)
+        self.assertEqual(actual, expected)
+        self.assertNotEqual(uid, prev_uid)
+        prev_uid = uid
 
-good_headers = {'Content-Type': 'application/json', 'Accept': 'application/json'}
+        # check a _portion_ of the contents of the loaded file
+        uid = c.send_query("show", {"start":1, "end":5, "state": hello_state})
+        actual = c.wait_for_reply_to(uid)
+        self.assertEqual(actual, show_res(content='ello',uid=uid,state=hello_state))
+        self.assertNotEqual(uid, prev_uid)
+        prev_uid = uid
 
-# Parse error for request body
-post_response = requests.post("http://localhost:8080/", headers=good_headers)
-assert(post_response.status_code == 400)
+        # clear the loaded file
+        uid = c.send_command("clear", {"state": hello_state})
+        actual = c.wait_for_reply_to(uid)
+        self.assertTrue('result' in actual and 'state' in actual['result'])
+        cleared_state = actual['result']['state']
+        expected = {'result':{'state':cleared_state,'stdout':'','stderr':'','answer':[]},'jsonrpc':'2.0','id':uid}
+        self.assertEqual(actual, expected)
+        self.assertNotEqual(cleared_state, hello_state)
+        self.assertNotEqual(uid, prev_uid)
 
-post_response = requests.request('POST', "http://localhost:8080/", headers=good_headers, data='{"id":0, "jsonrpc": "2.0", "method": "clear", "params":{"state": null}}')
-assert(post_response.status_code == 200)
+        # check that the file contents cleared
+        uid = c.send_query("show", {"state": cleared_state})
+        actual = c.wait_for_reply_to(uid)
+        self.assertEqual(actual, show_res(content='',uid=uid,state=cleared_state))
 
-os.killpg(os.getpgid(p_http.pid), signal.SIGKILL)
+        ## Negative tests -- make sure the server errors as we expect
 
-# Test the custom command line argument to load a file at server start
-hello_file = file_dir.joinpath('hello.txt')
-c_preload = argo.ServerConnection(
-              argo.StdIOProcess("cabal v2-exec file-echo-api --verbose=0 -- stdio --file \"" + str(hello_file) + "\""))
-uid = c_preload.send_message("show", {"state": None})
-actual = c_preload.wait_for_reply_to(uid)
-expected = {'result':{'state':None,'stdout':'','stderr':'','answer':{'value':'Hello World!\n'}},'jsonrpc':'2.0','id':uid}
-assert(actual == expected)
+        # Method not found
+        uid = c.send_command("bad function", {"state": cleared_state})
+        actual = c.wait_for_reply_to(uid)
+        expected = {'error':{'data':{'stdout':None,'data':'bad function','stderr':None},'code':-32601,'message':'Method not found'},'jsonrpc':'2.0','id':uid}
+        self.assertEqual(actual, expected)
+
+        # Invalid params
+        uid = c.send_command("load", {"file path": 12345, "state": cleared_state})
+        actual = c.wait_for_reply_to(uid)
+        expected = {'error':{'data':{'stdout':'','data':{'state':cleared_state,'file path':12345},'stderr':''},'code':-32602,'message':'Invalid params: expected String, but encountered Number'},'jsonrpc':'2.0','id':uid}
+        self.assertEqual(actual, expected)
+
+        # load a nonexistent file, check error that is returned
+        nonexistent_file = file_dir.joinpath('nonexistent.txt')
+        if nonexistent_file.is_file():
+            print('ERROR: ' + str(nonexistent_file) + ' was expected to not exist, but it does!')
+            assert(False)
+        uid = c.send_command("load", {"file path": str(nonexistent_file), "state": cleared_state})
+        actual = c.wait_for_reply_to(uid)
+        expected = {'error':{'data':{'stdout':'','data':{'path':str(nonexistent_file)},'stderr':''},'code':20051,'message':'File doesn\'t exist: ' + str(nonexistent_file)},'jsonrpc':'2.0','id':uid}
+        self.assertEqual(actual, expected)
+
+
+        # cause server to have an internal error
+        uid = c.send_command("implode", {"state": cleared_state})
+        actual = c.wait_for_reply_to(uid)
+        expected = {'error':{'data':{'stdout':'','stderr':''},'code':-32603,'message':'Internal error'},'jsonrpc':'2.0','id':uid}
+        self.assertEqual(actual, expected)
+
+        # send a request with an invalid state id
+        uid = c.send_query("show", {"state": "12345678-9101-1121-3141-516171819202"})
+        actual = c.wait_for_reply_to(uid)
+        expected = {'error':{'data':{'stdout':None,'data':'12345678-9101-1121-3141-516171819202','stderr':None},'code':20,'message':'Unknown state ID'},'jsonrpc':'2.0','id':uid}
+        self.assertEqual(actual, expected)
+
+        # invalid request (missing JSON-RPC required fields)
+        invalid_request = {'jsonrpc': '2.0','method': 'bad request', 'id':1}
+        c.process.send_one_message(json.dumps(invalid_request))
+        actual = c.wait_for_reply_to(None)
+        expected = {'error':{'data':{'stdout':None,'data':'Error in $: key \"params\" not found','stderr':None},'code':-32700,'message':'Parse error'},'jsonrpc':'2.0','id':None}
+        self.assertEqual(actual, expected)
+
+        # invalid request (Bad JSON)
+        invalid_request = "BAAAAAD JSON"
+        c.process.send_one_message(invalid_request)
+        time.sleep(2) # pause before fetching response so we don't just read the previous response whose JSON-RPC id is `null`
+        actual = c.wait_for_reply_to(None)
+        expected = {'error':{'data':{'stdout':None,'data':'Error in $: Failed reading: not a valid json value at \'BAAAAADJSON\'','stderr':None},'code':-32700,'message':'Parse error'},'jsonrpc':'2.0','id':None}
+        self.assertEqual(actual, expected)
+
+    def test_caching(self):
+        c = self.get_connection()
+        iterations = self.get_caching_iterations()
+
+        # set cache max size to 10 to start
+        c.send_notification("set cache limit", {"state": None, "cache limit": 10})
+
+        # Check that their is nothing to show if we haven't loaded a file yet
+        uid = c.send_query("show", {"state": None})
+        actual = c.wait_for_reply_to(uid)
+        expected = show_res(content='',uid=uid,state=None)
+        self.assertEqual(actual, expected)
+
+        # Make a misc state to pin and pin it
+        uid = c.send_command("prepend", {"content":"I am in a pinned state", "state": None})
+        actual = c.wait_for_reply_to(uid)
+        pinned_state = actual['result']['state']
+        uid = c.send_query("show", {"state": pinned_state})
+        actual = c.wait_for_reply_to(uid)
+        expected = show_res(content="I am in a pinned state",uid=uid,state=pinned_state)
+        self.assertEqual(actual, expected)
+
+        # pin the state
+        c.send_notification("pin state", {"state": pinned_state, "state to pin": pinned_state})
+
+        # Check that the pinned state is reachable
+        uid = c.send_query("show", {"state": pinned_state})
+        actual = c.wait_for_reply_to(uid)
+        expected = show_res(content="I am in a pinned state",uid=uid,state=pinned_state)
+        self.assertEqual(actual, expected)
+
+        seen_states = [None]
+        expected = ''
+
+        # Basically append 10 'c's onto the empty string in a funny way, and then clear the string, over and over
+        # (i.e., make a lot of new states, not all of which should fit in the ephemeral cache)
+        for i in range(1,iterations):
+            # append "abc" on the left
+            uid = c.send_command("prepend", {"content":"abc", "state": seen_states[len(seen_states) - 1]})
+            seen_states.append(c.wait_for_reply_to(uid)['result']['state'])
+            if i % 10 == 0:
+                # clear the string by dropping the "ab" and 10 accumulated "c"s from the front
+                expected = ""
+                uid = c.send_command("drop", {"count":12, "state": seen_states[len(seen_states) - 1]})
+                seen_states.append(c.wait_for_reply_to(uid)['result']['state'])
+                uid = c.send_query("show", {"state": seen_states[len(seen_states) - 1]})
+                actual = c.wait_for_reply_to(uid)['result']['answer']['value']
+                self.assertEqual(expected, actual)
+            else:
+                uid = c.send_command("drop", {"count":2, "state": seen_states[len(seen_states) - 1]})
+                seen_states.append(c.wait_for_reply_to(uid)['result']['state'])
+                uid = c.send_query("show", {"state": seen_states[len(seen_states) - 1]})
+                actual = c.wait_for_reply_to(uid)['result']['answer']['value']
+                # we dropped the "ab", but the "c" remains
+                expected += 'c'
+                self.assertEqual(expected, actual)
+            uid = c.send_query("show", {"state": seen_states[1]})
+            actual = c.wait_for_reply_to(uid)['result']['answer']['value']
+            self.assertEqual('abc', actual)
+
+
+        # Check that the initial state is still reachable
+        uid = c.send_query("show", {"state": None})
+        actual = c.wait_for_reply_to(uid)
+        self.assertEqual(actual, show_res(content="",uid=uid,state=None))
+
+
+        # Check that the last couple states and the one we kept revisiting are still live/reachable
+        uid = c.send_query("show", {"state": seen_states[len(seen_states) - 1]})
+        actual = c.wait_for_reply_to(uid)['result']['answer']['value']
+        self.assertEqual(expected, actual)
+        uid = c.send_query("show", {"state": seen_states[len(seen_states) - 2]})
+        actual = c.wait_for_reply_to(uid)['result']['answer']['value']
+        self.assertEqual('ab' + expected, actual)
+        uid = c.send_query("show", {"state": seen_states[len(seen_states) - 3]})
+        actual = c.wait_for_reply_to(uid)['result']['answer']['value']
+        self.assertEqual(expected[:len(expected) - 1], actual)
+        uid = c.send_query("show", {"state": seen_states[1]})
+        actual = c.wait_for_reply_to(uid)['result']['answer']['value']
+        self.assertEqual('abc', actual)
+
+        # Check that old stale states are no longer reachable in the cache
+        for i in range(2,50):
+            uid = c.send_query("show", {"state": seen_states[i]})
+            actual = c.wait_for_reply_to(uid)
+            expected = bad_state_res(uid=uid,state=seen_states[i])
+            self.assertEqual(actual, expected)
+
+        # Check that the pinned state is still reachable
+        uid = c.send_query("show", {"state": pinned_state})
+        actual = c.wait_for_reply_to(uid)
+        expected = show_res(content="I am in a pinned state",uid=uid,state=pinned_state)
+        self.assertEqual(actual, expected)
+
+        # unpinn the pinned state
+        c.send_notification("unpin state", {"state": pinned_state, "state to unpin":pinned_state})
+        # create some misc traffic so the now unpinned state goes away
+        gen_misc_states(c, 100)
+
+        # send a request with a now invalid state id
+        uid = c.send_query("show", {"state": pinned_state})
+        actual = c.wait_for_reply_to(uid)
+        expected = bad_state_res(uid=uid,state=pinned_state)
+        self.assertEqual(actual, expected)
+
+        # make a new pinned state
+        uid = c.send_command("prepend", {"content":"I am another pinned state", "state": None})
+        pinned_state = c.wait_for_reply_to(uid)['result']['state']
+        c.send_notification("pin state", {"state": pinned_state, "state to pin": pinned_state})
+        # misc traffic
+        gen_misc_states(c, 100)
+        # check that it's still pinned
+        uid = c.send_query("show", {"state": pinned_state})
+        actual = c.wait_for_reply_to(uid)
+        self.assertEqual(actual['result']['answer']['value'], "I am another pinned state")
+
+        # unpinn the pinned state by unpinning all pinned states
+        c.send_notification("unpin all states", {"state": pinned_state})
+        # create some misc traffic so the now unpinned state goes away
+        gen_misc_states(c, 100)
+
+        # send a request with a now invalid state id
+        uid = c.send_query("show", {"state": pinned_state})
+        actual = c.wait_for_reply_to(uid)
+        expected = bad_state_res(uid=uid,state=pinned_state)
+        self.assertEqual(actual, expected)
+
+        # reduce the cache max size to 0
+        c.send_notification("set cache limit", {"state": None, "cache limit": 0})
+        
+        # Now make sure we can linearly use the states, but anything older than the previous is gone.
+        for i in range(1, 20):
+            # append "foo" on the left then remove it, over and over to churn through states
+            uid = c.send_command("prepend", {"content":"foo", "state": None})
+            state1 = c.wait_for_reply_to(uid)['result']['state']
+            uid = c.send_query("show", {"state": state1})
+            actual = c.wait_for_reply_to(uid)
+            self.assertEqual(actual, show_res(content="foo",uid=uid,state=state1))
+            uid = c.send_command("drop", {"count":3, "state": state1})
+            state2 = c.wait_for_reply_to(uid)['result']['state']
+            uid = c.send_query("show", {"state": state2})
+            actual = c.wait_for_reply_to(uid)
+            self.assertEqual(actual, show_res(content="",uid=uid,state=state2))
+            # check that the first state is missing as we expect
+            uid = c.send_query("show", {"state": state1})
+            actual = c.wait_for_reply_to(uid)
+            self.assertEqual(actual, bad_state_res(uid=uid,state=state1))
+
+
+
+
+class RemoteSocketProcessTests(GenericFileEchoTests, unittest.TestCase):
+
+    # to be implemented by classes extending this one
+    def get_connection(self):
+        return argo.ServerConnection(
+                argo.RemoteSocketProcess('localhost', 50005, ipv6=True))
+
+    def get_caching_iterations(self):
+        return 100
+
+class DynamicSocketProcessTests(GenericFileEchoTests, unittest.TestCase):
+
+    # to be implemented by classes extending this one
+    def get_connection(self):
+        return argo.ServerConnection(
+                argo.DynamicSocketProcess("cabal v2-exec file-echo-api --verbose=0 -- socket --port 50005"))
+
+    def get_caching_iterations(self):
+        return 100
+
+class StdIOProcessTests(GenericFileEchoTests, unittest.TestCase):
+
+    # to be implemented by classes extending this one
+    def get_connection(self):
+        return argo.ServerConnection(
+                argo.StdIOProcess("cabal v2-exec file-echo-api --verbose=0 -- stdio"))
+
+    def get_caching_iterations(self):
+        return 100
+
+
+class HttpTests(GenericFileEchoTests, unittest.TestCase):
+
+    # to be implemented by classes extending this one
+    def get_connection(self):
+        return argo.ServerConnection(
+                argo.HttpProcess(url="http://localhost:8080/"))
+
+    def get_caching_iterations(self):
+        return 100
+
+    def test_http_behaviors(self):
+        ### Additional tests for the HTTP server ###
+
+        # Ensure that only POST is allowed to the designated URL
+        get_response = requests.get("http://localhost:8080/")
+        self.assertEqual(get_response.status_code, 405)
+
+        # Ensure that other URLs give 404
+        get_response = requests.get("http://localhost:8080/some/other/resource")
+        self.assertEqual(get_response.status_code, 404)
+
+        post_response = requests.post("http://localhost:8080/some/other/resource")
+        self.assertEqual(post_response.status_code, 404)
+
+        # Wrong content-type
+        post_response = requests.post("http://localhost:8080/")
+        self.assertEqual(post_response.status_code, 415)
+
+        good_headers = {'Content-Type': 'application/json', 'Accept': 'application/json'}
+
+        # Parse error for request body
+        post_response = requests.post("http://localhost:8080/", headers=good_headers)
+        self.assertEqual(post_response.status_code, 400)
+
+        post_response = requests.request('POST', "http://localhost:8080/", headers=good_headers, data='{"id":0, "jsonrpc": "2.0", "method": "clear", "params":{"state": null}}')
+        self.assertEqual(post_response.status_code, 200)
+
+
+
+class LoadOnLaunchTests(unittest.TestCase):
+
+    # to be implemented by classes extending this one
+    def test_load_on_launch(self):
+        c_preload = argo.ServerConnection(
+                    argo.StdIOProcess("cabal v2-exec file-echo-api --verbose=0 -- stdio --file \"" + str(hello_file) + "\""))
+        uid = c_preload.send_query("show", {"state": None})
+        actual = c_preload.wait_for_reply_to(uid)
+        expected = {'result':{'state':None,'stdout':'','stderr':'','answer':{'value':'Hello World!\n'}},'jsonrpc':'2.0','id':uid}
+        self.assertEqual(actual, expected)
+
+
+unittest.main()

--- a/file-echo-api/test/Test.hs
+++ b/file-echo-api/test/Test.hs
@@ -18,7 +18,6 @@ main =
      withPython3venv (Just reqs) $ \pip python ->
        do pySrc <- getArgoPythonFile "."
           testScriptsDir <- getDataFileName "test-scripts/"
-          --let testScriptsDir = "/Users/andrew/Repos/GRINDSTONE/argo/file-echo-api/test-scripts"
           pip ["install", pySrc]
           putStrLn "pipped"
 

--- a/python/argo/interaction.py
+++ b/python/argo/interaction.py
@@ -61,7 +61,7 @@ class Interaction:
         self.request_id = \
             connection. \
             server_connection. \
-            send_message(self._method, self._params)
+            send_command(self._method, self._params)
 
     def add_param(self, name: str, val: Any) -> None:
         self._params[name] = val


### PR DESCRIPTION
This PR modifies Argo servers to guarantee a bound on memory usage.
This is accomplished by:
  1. keeping only the initial server state cached indefinitely,
  2. keeping alive a (customizable) number of recently used states
     while evicting others from the cache when it fills (along with
     any no longer in-use file contents loaded from disk), and
  3. allows states to be explicitly pinned in the cache, which would
     keep them in memory until they are explicitly unpinned.

The main cost of this change is that arbitrary states no longer
in cache cannot be "replayed" or "resurrected" automatically when
a request mentioning them is received once they are evicted from the cache
(such a state would either have to be manually pinned or rebuilt
by the client through standard interactions from a live state).

IF this change is a desirable step towards addressing https://github.com/GaloisInc/argo/issues/136, we may wish to add the following before merging:
+ [x] expose state cache pinning/unpinning/flushing capabilities to clients
+ [x] expose a method for querying which states are currently live (may or may not be useful)
+ [x] allow easy way to configure cache size when starting a server
+ [ ] document changes to `file-echo-api` (some methods were added to
        test the caching behavior)