### PR TITLE
feat: mutable file-echo-api with tests

### DIFF
--- a/argo/argo.cabal
+++ b/argo/argo.cabal
@@ -8,6 +8,13 @@ maintainer:    dtc@galois.com
 category:      Network
 extra-source-files: CHANGELOG.md
 
+common errors
+  ghc-options:
+    -Werror=missing-fields
+    -Werror=incomplete-patterns
+    -Werror=missing-methods
+    -Werror=overlapping-patterns
+
 common warnings
   ghc-options:
     -Wall
@@ -36,7 +43,6 @@ common deps
     filepath                    ^>= 1.4,
     hashable                    >= 1.2 && < 1.4,
     http-types                  ^>= 0.12,
-    lens                        >= 4.17 && < 4.20,
     mtl                         ^>= 2.2,
     network                     >= 3.0.1,
     optparse-applicative        >= 0.14 && < 0.17,
@@ -53,7 +59,7 @@ common deps
 
 
 library
-  import: deps, warnings
+  import: deps, warnings, errors
   exposed-modules:
     Argo
     Argo.DefaultMain
@@ -69,7 +75,7 @@ library
 
 
 test-suite test-argo
-  import:              deps, warnings
+  import:              deps, warnings, errors
   type:                exitcode-stdio-1.0
   default-language:    Haskell2010
   hs-source-dirs:      test

--- a/argo/argo.cabal
+++ b/argo/argo.cabal
@@ -10,7 +10,7 @@ extra-source-files: CHANGELOG.md
 
 common warnings
   ghc-options:
-    -Weverything
+    -Wall
     -Wno-missing-exported-signatures
     -Wno-missing-import-lists
     -Wno-missed-specialisations

--- a/argo/src/Argo.hs
+++ b/argo/src/Argo.hs
@@ -309,7 +309,7 @@ methodDocs = lens _methodDocs (\m t -> m { _methodDocs = t })
 mkApp ::
   Text {- ^ Application name -} ->
   [Doc.Block] {- ^ Documentation -} ->
-  ServerOpts {- ^ Server options to use at launch. -}->
+  ServerOpts {- ^ Server options to use at launch. -} ->
   ((FilePath -> IO B.ByteString) -> IO s) {- ^ how to get the initial state -} ->
   [AppMethod s]
   {- ^ Individual methods -} ->

--- a/argo/src/Argo.hs
+++ b/argo/src/Argo.hs
@@ -19,26 +19,30 @@
 module Argo
   ( -- * Primary interface to JSON-RPC
     App
-  , mkApp, mkDefaultApp
+  , mkApp
   , appName
   , appDocumentation
+  , defaultAppOpts
+  , StateMutability(..)
+  , AppOpts
   -- * Method Options
   , FileSystemMode(..)
   , MethodOptions(..)
   , defaultMethodOptions
   -- * Defining methods
   , AppMethod
-  , MethodType(..)
-  , Method(..)
-  , runMethod
-  , method
-  -- * Manipulating state in methods
+  , Method
+  , Command
+  , Notification
+  , command
+  , notification
+  -- * Manipulating app state in methods
   , getState
   , modifyState
   , setState
-  -- * Manipulating internal server state
-  , pinState, unpinState
-  , unpinAllStates, setCacheLimit
+  -- * Manipulating internal server state in notifications
+  , destroyState
+  , destroyAllStates
   -- * File I/O in methods that respects caching
   , getFileReader
   -- * "printf"-style debugging in methods
@@ -66,8 +70,9 @@ module Argo
   -- * System info
   getFileSystemMode,
   -- * AppMethod info
-  methodName, methodType, methodImplementation,
-  methodParamDocs, methodDocs
+  methodName,
+  methodParamDocs,
+  methodDocs
   ) where
 
 import Control.Concurrent
@@ -75,7 +80,6 @@ import Control.Monad
 import Control.Monad.Reader
 import Control.Monad.State
 import Control.Exception hiding (TypeError)
-import Control.Lens hiding ((.=))
 import qualified Data.Aeson as JSON
 import Data.Aeson ((.:), (.:!), (.=))
 import qualified Data.Aeson.Types as JSON (Parser, typeMismatch)
@@ -85,12 +89,14 @@ import Data.Foldable (for_)
 import Data.List.NonEmpty (NonEmpty(..))
 import Data.Map (Map)
 import qualified Data.Map as M
+import qualified Data.HashMap.Strict as HM
 import Data.Maybe (maybeToList)
 import Data.Scientific (Scientific)
 import Data.Text ( Text )
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
 import GHC.Stack
+import Numeric.Natural ( Natural )
 import Network.HTTP.Types.Method (StdMethod(..))
 import Network.HTTP.Types.Status
 import System.IO
@@ -108,6 +114,17 @@ jsonRPCVersion = "2.0"
 
 --------------------------------------------------------------------------------
 
+-- | Options affecting the how the server runs/supports the app.
+data AppOpts =
+  AppOpts
+  {
+    appStateMutability :: StateMutability
+    -- ^ Whether or not the underlying application state is mutable
+  }
+
+defaultAppOpts :: StateMutability -> AppOpts
+defaultAppOpts stateMut = AppOpts { appStateMutability = stateMut}
+
 data FileSystemMode
   = ReadOnly
   | ReadWrite
@@ -120,22 +137,8 @@ data MethodOptions =
     -- ReadOnly prohibits creating or writing files.
     , optLogger :: Text -> IO ()
     -- ^ A function to use for logging debug messages.
-    }
-
-data MethodContext =
-  MethodContext
-    { mctxOptions :: MethodOptions
-    , mctxFileReader :: FilePath -> IO B.ByteString
-    -- ^ A function returning the contents of the named file,
-    -- potentially from a cache.
-    , mctxStatePin :: StateID -> IO ()
-    -- ^ A function for pinning a state (i.e., adding it to the persistent cache).
-    , mctxStateUnpin :: StateID -> IO ()
-    -- ^ A function for unpinning a state (i.e., removing it from the persistent cache).
-    , mctxStateUnpinAll :: IO ()
-    -- ^ A function for unpinning all pinned states (i.e., clearing the persistent cache).
-    , mctxSetECacheLimit :: Int -> IO ()
-    -- ^ A function for setting the max size of the ephemeral cache.
+    , optMaxOccupancy :: Natural
+    -- ^ How many simultaneous states can be live at once?
     }
 
 defaultMethodOptions :: MethodOptions
@@ -143,208 +146,240 @@ defaultMethodOptions =
   MethodOptions
     { optFileSystemMode = ReadWrite
     , optLogger = const (return ())
+    , optMaxOccupancy = 10
     }
+
+data CommandContext =
+  CommandContext
+  { cmdCtxMOptions :: MethodOptions
+  , cmdCtxFileReader :: FilePath -> IO B.ByteString
+  }
+
+data NotificationContext =
+  NotificationContext
+  { ntfCtxMOptions :: MethodOptions
+  , ntfCtxFileReader :: FilePath -> IO B.ByteString
+  -- ^ A function returning the contents of the named file,
+  -- potentially from a cache.
+  , ntfCtxDestroyState :: StateID -> IO ()
+  -- ^ A function for unpinning a state (i.e., removing it from the persistent cache).
+  , ntfCtxDestroyAllStates :: IO ()
+  -- ^ A function for unpinning all pinned states (i.e., clearing the persistent cache).
+  }
+
 
 --------------------------------------------------------------------------------
 
 -- | A server has /state/, and a collection of (potentially) stateful /methods/,
 -- each of which is a function from the JSON value representing its parameters
 -- to a JSON value representing its response.
-newtype Method state result
-  = Method (ReaderT MethodContext (StateT state IO) result)
-  deriving (Functor, Applicative, Monad, MonadIO)
+newtype Command state result
+  = Command (ReaderT CommandContext (StateT state IO) result)
+  deriving (Functor, Applicative, Monad, MonadIO, MonadState state)
 
-runMethod :: Method state result -> MethodContext -> state -> IO (state, result)
-runMethod (Method m) mctx s = flop <$> runStateT (runReaderT m mctx) s
+runCommand :: Command state result -> CommandContext -> state -> IO (state, result)
+runCommand (Command m) mctx s = flop <$> runStateT (runReaderT m mctx) s
   where flop (x, y) = (y, x)
 
+newtype Notification result
+  = Notification (ReaderT NotificationContext IO result)
+  deriving (Functor, Applicative, Monad, MonadIO)
+
+runNotification :: Notification () -> NotificationContext -> IO ()
+runNotification (Notification m) mctx = void $ runReaderT m mctx
 
 
--- | A 'Method' may be one of three different sorts
-data MethodType
-  = Command  -- ^ can modify state and can reply to the client
-  | Query    -- ^ can /not/ modify state, but can reply to the client
-  | Notification  -- ^ can modify state, but can /not/ reply to the client
-  deriving (Eq, Ord, Show)
+data AppCommand appState =
+  AppCommand
+  { commandName :: !Text
+  , commandImplementation :: !(JSON.Value -> Command appState JSON.Value)
+  , commandParamDocs :: ![(Text, Doc.Block)]
+  , commandDocs :: !Doc.Block
+  }
 
--- | Given an arbitrary 'Method', wrap its input and output in JSON
+data AppNotification =
+  AppNotification
+  { notificationName :: !Text
+  , notificationImplementation :: !(JSON.Value -> Notification ())
+  , notificationParamDocs :: ![(Text, Doc.Block)]
+  , notificationDocs :: !Doc.Block
+  }
+
+data AppMethod appState
+  = CommandMethod (AppCommand appState)
+  | NotificationMethod AppNotification
+
+methodName :: AppMethod appState -> Text
+methodName (CommandMethod m) = commandName m
+methodName (NotificationMethod m) = notificationName m
+
+methodKind :: AppMethod appState -> Text
+methodKind CommandMethod{} = "command"
+methodKind NotificationMethod{} = "notification"
+
+methodParamDocs :: AppMethod appState -> [(Text, Doc.Block)]
+methodParamDocs (CommandMethod m) = commandParamDocs m
+methodParamDocs (NotificationMethod m) = notificationParamDocs m
+
+methodDocs :: AppMethod appState -> Doc.Block
+methodDocs (CommandMethod m) = commandDocs m
+methodDocs (NotificationMethod m) = notificationDocs m
+
+
+-- | Given an arbitrary 'Command', wrap its input and output in JSON
 -- serialization. Note that because the JSON representation of a 'JSON.Value' is
 -- itself, you can manipulate raw JSON inputs/outputs by using 'JSON.Value' as a
--- parameter or result type. The resultant 'Method' may throw an 'invalidParams'
+-- parameter or result type. The resultant 'Command' may throw an 'invalidParams'
 -- exception.
-method ::
+command ::
   forall params result state.
   (JSON.FromJSON params, Doc.DescribedParams params, JSON.ToJSON result) =>
   Text ->
-  MethodType ->
   Doc.Block ->
-  (params -> Method state result) ->
+  (params -> Command state result) ->
   AppMethod state
-method name ty doc f =
+command name doc f =
   let impl =
         \p ->
          case JSON.fromJSON @params p of
            JSON.Error msg -> raise $ invalidParams msg p
            JSON.Success params -> JSON.toJSON <$> f params
-  in AppMethod { _methodName = name
-               , _methodType = ty
-               , _methodImplementation = impl
-               , _methodParamDocs = Doc.parameterFieldDescription @params
-               , _methodDocs = doc
-               }
+  in CommandMethod $ AppCommand
+     { commandName = name
+     , commandImplementation = impl
+     , commandParamDocs = Doc.parameterFieldDescription @params
+     , commandDocs = doc
+     }
 
--- | Get the logger from the server
-getDebugLogger :: Method state (Text -> IO ())
-getDebugLogger = Method (asks (optLogger . mctxOptions))
+-- | Given an arbitrary 'Notification', wrap its input and output in JSON
+-- serialization. Note that because the JSON representation of a 'JSON.Value' is
+-- itself, you can manipulate raw JSON inputs/outputs by using 'JSON.Value' as a
+-- parameter or result type. The resultant 'Notification' may throw an 'invalidParams'
+-- exception.
+notification ::
+  forall params state.
+  (JSON.FromJSON params, Doc.DescribedParams params) =>
+  Text ->
+  Doc.Block ->
+  (params -> Notification ()) ->
+  AppMethod state
+notification name doc f =
+  let impl =
+        \p ->
+         case JSON.fromJSON @params p of
+           JSON.Error msg -> raise $ invalidParams msg p
+           JSON.Success params -> f params
+  in NotificationMethod $ AppNotification
+     { notificationName = name
+     , notificationImplementation = impl
+     , notificationParamDocs = Doc.parameterFieldDescription @params
+     , notificationDocs = doc
+     }
 
--- | Log a message for debugging
-debugLog :: Text -> Method state ()
-debugLog message =
-  do logger <- getDebugLogger
-     liftIO $ logger message
+class Method m where
+  -- | Get the logger from the server
+  getDebugLogger :: m (Text -> IO ())
+  -- | Log a message for debugging
+  debugLog :: Text -> m ()
+  -- | Get the file reader from the server
+  getFileReader :: m (FilePath -> IO B.ByteString)
+  -- | Get the file system mode from the server
+  getFileSystemMode :: m FileSystemMode
+  -- | Raise a 'JSONRPCException' within a 'Method'
+  raise :: JSONRPCException -> m a
 
--- | Get the file reader from the server
-getFileReader :: Method state (FilePath -> IO B.ByteString)
-getFileReader = Method (asks mctxFileReader)
+instance Method (Command state) where
+  getDebugLogger = Command (asks (optLogger . cmdCtxMOptions))
+  debugLog message = do
+    logger <- getDebugLogger
+    liftIO $ logger message
+  getFileReader = Command (asks cmdCtxFileReader)
+  getFileSystemMode = Command (asks (optFileSystemMode . cmdCtxMOptions))
+  raise = liftIO . throwIO
 
--- | Get the file system mode from the server
-getFileSystemMode :: Method state FileSystemMode
-getFileSystemMode = Method (asks (optFileSystemMode . mctxOptions))
+instance Method Notification where
+  getDebugLogger = Notification (asks (optLogger . ntfCtxMOptions))
+  debugLog message = do
+    logger <- getDebugLogger
+    liftIO $ logger message
+  getFileReader = Notification (asks ntfCtxFileReader)
+  getFileSystemMode = Notification (asks (optFileSystemMode . ntfCtxMOptions))
+  raise = liftIO . throwIO
+
 
 -- | Get the state of the server
-getState :: Method state state
-getState = Method get
+getState :: Command s s
+getState = Command get
 
 -- | Modify the state of the server with some function
-modifyState :: (state -> state) -> Method state ()
-modifyState f = Method (modify f)
+modifyState :: (s -> s) -> Command s ()
+modifyState f = Command (modify f)
 
 -- | Set the state of the server
-setState :: state -> Method state ()
-setState = Method . put
-
--- | Raise a 'JSONRPCException' within a 'Method'
-raise :: JSONRPCException -> Method state a
-raise = liftIO . throwIO
-
--- | Pin the specified state.
-pinState :: StateID -> Method state ()
-pinState sid = Method $ do
-  pin <- asks mctxStatePin
-  liftIO $ pin sid
-
--- | Unpin the specified state.
-unpinState :: StateID -> Method state ()
-unpinState sid = Method $ do
-  unpin <- asks mctxStateUnpin
-  liftIO $ unpin sid
-
--- | Unpin all states.
-unpinAllStates :: Method state ()
-unpinAllStates = Method $ do
-  unpinAll <- asks mctxStateUnpinAll
-  liftIO $ unpinAll
+setState :: s -> Command s ()
+setState = Command . put
 
 
--- | Set the limit for the ephemeral cache.
-setCacheLimit :: Int -> Method state ()
-setCacheLimit n = Method $ do
-  setCacheSize <- asks mctxSetECacheLimit
-  liftIO $ setCacheSize n
+-- | Destroy a state.
+destroyState :: StateID -> Notification ()
+destroyState sid = Notification $ do
+  destroy <- asks ntfCtxDestroyState
+  liftIO $ destroy sid
+
+
+-- | Destroy all states.
+destroyAllStates :: Notification ()
+destroyAllStates = Notification $ do
+  destroyAll <- asks ntfCtxDestroyAllStates
+  liftIO $ destroyAll
 
 
 --------------------------------------------------------------------------------
 
 -- | An application is a state and a mapping from names to methods.
 data App s =
-  App { _serverState :: MVar (ServerState s)
-      , _appMethods :: Map Text (MethodType, JSON.Value -> Method s JSON.Value)
-      , _appName :: Text
-      , _appDocumentation :: [Doc.Block]
-      }
-
--- | Focus on the state var in an 'App'
-serverState :: Lens' (App s) (MVar (ServerState s))
-serverState = lens _serverState (\a s -> a { _serverState = s })
-
--- | Focus on the 'Method's in an 'App'
-appMethods ::
-  Lens' (App s) (Map Text (MethodType, JSON.Value -> Method s JSON.Value))
-appMethods = lens _appMethods (\a s -> a { _appMethods = s })
-
-appName :: Lens' (App s) Text
-appName = lens _appName (\a n -> a { _appName = n })
-
-appDocumentation :: Lens' (App s) [Doc.Block]
-appDocumentation = lens _appDocumentation (\a d -> a { _appDocumentation = d })
-
-data AppMethod s =
-  AppMethod
-  { _methodName :: !Text
-  , _methodType :: !MethodType
-  , _methodImplementation :: !(JSON.Value -> Method s JSON.Value)
-  , _methodParamDocs :: ![(Text, Doc.Block)]
-  , _methodDocs :: !Doc.Block
+  App 
+  { serverState :: MVar (ServerState s)
+  , appMethods :: Map Text (AppMethod s)
+  , appName :: Text
+  , appDocumentation :: [Doc.Block]
   }
 
 
-methodName :: Lens' (AppMethod s) Text
-methodName = lens _methodName (\m n -> m { _methodName = n })
-
-methodType :: Lens' (AppMethod s) MethodType
-methodType = lens _methodType (\m t -> m { _methodType = t })
-
-methodImplementation :: Lens' (AppMethod s) (JSON.Value -> Method s JSON.Value)
-methodImplementation = lens _methodImplementation (\m impl -> m { _methodImplementation = impl })
-
-methodParamDocs :: Lens' (AppMethod s) [(Text, Doc.Block)]
-methodParamDocs = lens _methodParamDocs (\m t -> m { _methodParamDocs = t })
-
-methodDocs :: Lens' (AppMethod s) Doc.Block
-methodDocs = lens _methodDocs (\m t -> m { _methodDocs = t })
-
-
 -- | Construct an application from an initial state and a mapping from method
--- names to methods.
+-- names to methods. This app's state is assumed to be pure.
 mkApp ::
   Text {- ^ Application name -} ->
   [Doc.Block] {- ^ Documentation -} ->
-  ServerOpts {- ^ Server options to use at launch. -} ->
+  AppOpts {- ^ App options to use at launch affecting how the server operates. -} ->
   ((FilePath -> IO B.ByteString) -> IO s) {- ^ how to get the initial state -} ->
   [AppMethod s]
   {- ^ Individual methods -} ->
   IO (App s)
-mkApp name docs opts initAppState methods =
-  App <$> (newMVar =<< initServerState opts initAppState)
-      <*> pure (M.fromList [ (name, (ty, impl)) | AppMethod name ty impl _ _ <- methods])
-      <*> pure name
-      <*> pure (docs ++
-                [Doc.Section "Methods"
-                   [ Doc.Section (name <> " " <> mt ty)
-                       [ if null paramDocs
-                         then Doc.Paragraph [Doc.Text "No parameters"]
-                         else Doc.DescriptionList
-                              [ (Doc.Literal field :| [], fieldDocs)
-                              | (field, fieldDocs) <- paramDocs
-                              ]
-                       , implDoc
-                       ]
-                   | AppMethod name ty _ paramDocs implDoc <- methods
-                   ]])
+mkApp name docs opts initAppState methods = do
+  initialState <- newMVar =<< initServerState (appStateMutability opts) initAppState
+  pure $ App
+    { serverState = initialState
+    , appMethods = M.fromList [ (methodName m, m)
+                              | m <- methods]
+    , appName = name
+    , appDocumentation = appDocs
+    }
+  where appDocs = 
+          docs ++
+          [Doc.Section "Methods"
+            [ Doc.Section (name <> " (" <> methodKind m <> ")")
+                [ if null (methodParamDocs m)
+                  then Doc.Paragraph [Doc.Text "No parameters"]
+                  else Doc.DescriptionList
+                        [ (Doc.Literal field :| [], fieldDocs)
+                        | (field, fieldDocs) <- (methodParamDocs m)
+                        ]
+                , (methodDocs m)
+                ]
+            | m <- methods
+            ]]
 
-  where mt ty = T.toLower (T.pack ("(" ++ show ty ++ ")"))
-
-
--- | Like @mkApp@ but uses Argo's default server options (see @defaultServerOpts@
---   in @Argo.ServerState@).
-mkDefaultApp ::
-  Text {- ^ Application name -} ->
-  [Doc.Block] {- ^ Documentation -} ->
-  ((FilePath -> IO B.ByteString) -> IO s) {- ^ how to get the initial state -} ->
-  [AppMethod s]
-  {- ^ method names paired with their implementations -} ->
-  IO (App s)
-mkDefaultApp nm docs initAppState methods = mkApp nm docs defaultServerOpts initAppState methods
 
 -- | JSON RPC exceptions should be thrown by method implementations when
 -- they want to return an error.
@@ -453,6 +488,28 @@ unknownStateID sid =
                    , errorStdErr = Nothing
                    }
 
+-- | The provided State ID is not one that the server has previously sent.
+unexpectedStateID :: JSONRPCException
+unexpectedStateID =
+  JSONRPCException { errorCode = 21
+                   , message = "Unexpected state ID"
+                   , errorData = Nothing
+                   , errorID = Nothing
+                   , errorStdOut = Nothing
+                   , errorStdErr = Nothing
+                   }
+
+-- | The server is already at capacity and cannot allocate a new state.
+serverAtCapacity :: JSONRPCException
+serverAtCapacity =
+  JSONRPCException { errorCode = 22
+                   , message   = "Server at max capacity"
+                   , errorData = Nothing
+                   , errorID   = Nothing
+                   , errorStdOut = Nothing
+                   , errorStdErr = Nothing
+                   }
+
 -- | Construct a 'JSONRPCException' from an error code, error text, and perhaps
 -- some data item to attach
 makeJSONRPCException :: JSON.ToJSON a => Integer -> Text -> Maybe a -> JSONRPCException
@@ -490,26 +547,17 @@ instance JSON.ToJSON RequestID where
   toJSON IDNull       = JSON.Null
 
 data Request =
-  Request { _requestMethod :: !Text
+  Request { requestMethod :: !Text
           -- ^ The method name to invoke
-          , _requestID :: !(Maybe RequestID)
+          , requestID :: !(Maybe RequestID)
           -- ^ Because the presence of null and the absence of the key are
           -- distinct, we have both a null constructor and wrap it in a Maybe.
           -- When the request ID is not present, the request is a notification
           -- and the field is Nothing.
-          , _requestParams :: !JSON.Object
+          , requestParams :: !JSON.Object
           -- ^ The parameters to the method, if any exist
           }
   deriving (Show)
-
-requestMethod :: Lens' Request Text
-requestMethod = lens _requestMethod (\r m -> r { _requestMethod = m })
-
-requestID :: Lens' Request (Maybe RequestID)
-requestID = lens _requestID (\r i -> r { _requestID = i })
-
-requestParams :: Lens' Request JSON.Object
-requestParams = lens _requestParams (\r m -> r { _requestParams = m })
 
 
 suchThat :: HasCallStack => JSON.Parser a -> (a -> Bool) -> JSON.Parser a
@@ -530,15 +578,15 @@ instance JSON.ToJSON Request where
   toJSON req =
     JSON.object
       [ "jsonrpc" .= jsonRPCVersion
-      , "method"  .= view requestMethod req
-      , "id"      .= view requestID     req
-      , "params"  .= view requestParams req ]
+      , "method"  .= requestMethod req
+      , "id"      .= requestID     req
+      , "params"  .= requestParams req ]
   toEncoding req =
     JSON.pairs $
       "jsonrpc" .= jsonRPCVersion         <>
-      "method"  .= view requestMethod req <>
-      "id"      .= view requestID     req <>
-      "params"  .= view requestParams req
+      "method"  .= requestMethod req <>
+      "id"      .= requestID     req <>
+      "params"  .= requestParams req
 
 -- | A response to a command or query.
 --
@@ -549,27 +597,12 @@ instance JSON.ToJSON Request where
 -- to exist, and the lack of a generalized 'ToJSON' instance prevents
 -- us from forgetting the ID when we encode it.
 data Response stateID a
-  = Response { _responseID :: !RequestID
-             , _responseAnswer :: !a
-             , _responseStdOut :: !(Maybe String)
-             , _responseStdErr :: !(Maybe String)
-             , _responseStateID :: !stateID
+  = Response { responseID :: !RequestID
+             , responseAnswer :: !a
+             , responseStdOut :: !(Maybe String)
+             , responseStdErr :: !(Maybe String)
+             , responseStateID :: !stateID
              } deriving (Eq, Ord, Show)
-
-responseID :: Lens' (Response stateID a) RequestID
-responseID = lens _responseID (\r m -> r { _responseID = m })
-
-responseAnswer :: Lens (Response stateID a) (Response stateID b) a b
-responseAnswer = lens _responseAnswer (\r m -> r { _responseAnswer = m })
-
-responseStdOut :: Lens' (Response stateID a) (Maybe String)
-responseStdOut = lens _responseStdOut (\r m -> r { _responseStdOut = m })
-
-responseStdErr :: Lens' (Response stateID a) (Maybe String)
-responseStdErr = lens _responseStdOut (\r m -> r { _responseStdOut = m })
-
-responseStateID :: Lens (Response stateID a) (Response stateID' a) stateID stateID'
-responseStateID = lens _responseStateID (\r sid -> r { _responseStateID = sid })
 
 instance JSON.FromJSON a => JSON.FromJSON (Response StateID a) where
   parseJSON =
@@ -588,12 +621,12 @@ instance JSON.ToJSON a => JSON.ToJSON (Response StateID a) where
   toJSON resp =
     JSON.object
       [ "jsonrpc" .= jsonRPCVersion
-      , "id"      .= view responseID resp
+      , "id"      .= responseID resp
       , "result"  .= JSON.object
-        [ "answer" .= view responseAnswer resp
-        , "stdout" .= view responseStdOut resp
-        , "stderr" .= view responseStdErr resp
-        , "state"  .= view responseStateID resp
+        [ "answer" .= responseAnswer resp
+        , "stdout" .= responseStdOut resp
+        , "stderr" .= responseStdErr resp
+        , "state"  .= responseStateID resp
         ]
       ]
 
@@ -615,48 +648,43 @@ methodCapture opts
    | optFileSystemMode opts == ReadOnly = hNoCapture
    | otherwise = hCaptureWrap
 
-runMethodResponse ::
-  Method s a ->
+tryOutErr ::
+  (forall a. [Handle] -> IO a -> IO (Maybe String, a)) ->
   RequestID ->
-  MethodContext ->
-  s ->
+  IO (s, a) ->
   IO (s, Response () a)
-execMethodSilently ::
-  Method s a ->
-  MethodContext ->
-  s ->
-  IO s
-(runMethodResponse, execMethodSilently) =
-  ( \m reqID mctx st ->
-      tryOutErr (methodCapture (mctxOptions mctx)) reqID (runMethod m mctx st)
-  , \m mctx st -> fst <$>
-      tryOutErr
-        hNoCapture
-        IDNull
-        (runMethod m mctx st) )
+tryOutErr capturer reqID action = do
+  (err, (out, res)) <-
+     capturer [stderr] . capturer [stdout] $
+     try @SomeException (try @JSONRPCException action)
+  tryPutOutErr out err
+  case res of
+    Left e -> let message = Just (JSON.String (T.pack (displayException e)))
+                in throwIO $ internalError { errorData = message }
+    Right (Left e) -> throwIO $ e { errorStdOut = out, errorStdErr = err }
+    Right (Right (st, answer)) -> pure (st, Response reqID answer out err ())
   where
-    tryOutErr ::
-      (forall a. [Handle] -> IO a -> IO (Maybe String, a)) ->
-      RequestID ->
-      IO (s, a) ->
-      IO (s, Response () a)
-    tryOutErr capturer reqID action =
-      do (err, (out, res)) <-
-           capturer [stderr] . capturer [stdout] $
-           try @SomeException (try @JSONRPCException action)
-         tryPutOutErr out err
-         either
-           (\e -> let message = Just (JSON.String (T.pack (displayException e)))
-                  in throwIO $ internalError { errorData = message })
-           (either
-              (\e -> throwIO $ e { errorStdOut = out, errorStdErr = err })
-              (\(st, answer) -> pure (st, Response reqID answer out err ())))
-           res
-      where
-        tryPutOutErr :: Maybe String -> Maybe String -> IO ()
-        tryPutOutErr out err =
-          do void $ try @IOException (traverse (hPutStr stdout) out)
-             void $ try @IOException (traverse (hPutStr stderr) err)
+    tryPutOutErr :: Maybe String -> Maybe String -> IO ()
+    tryPutOutErr out err = do
+      void $ try @IOException (traverse (hPutStr stdout) out)
+      void $ try @IOException (traverse (hPutStr stderr) err)
+
+execCommand ::
+  Command state result ->
+  RequestID ->
+  CommandContext ->
+  state ->
+  IO (state, Response () result)
+execCommand c reqID ctx st =
+  tryOutErr (methodCapture (cmdCtxMOptions ctx)) reqID (runCommand c ctx st)
+
+execNotification ::
+  Notification () ->
+  NotificationContext ->
+  IO ()
+execNotification n nctx = do
+  void $ tryOutErr hNoCapture IDNull (do runNotification n nctx; pure ((),()))
+
 
 handleRequest ::
   forall s.
@@ -667,82 +695,47 @@ handleRequest ::
   Request ->
   IO ()
 handleRequest opts respond app req =
-  case M.lookup method $ view appMethods app of
+  case M.lookup method $ appMethods app of
     Nothing -> throwIO $ (methodNotFound method) { errorID = reqID }
-    Just (Command, m) -> do
-      withRequestID $ \reqID ->
-        do stateID <- getStateID req
-           response <- withMVar theState $
-             \state -> do
-               getAppState state stateID >>=
-                 \case
-                   Nothing -> throwIO $ unknownStateID stateID
-                   Just initAppState ->
-                     do let mctx = MethodContext
-                                   { mctxOptions = opts
-                                   , mctxFileReader = freshStateFileReader state stateID
-                                   , mctxStatePin = pinAppState state
-                                   , mctxStateUnpin = unpinAppState state
-                                   , mctxStateUnpinAll = clearPersistentCache state
-                                   , mctxSetECacheLimit = setEphemeralCacheLimit state
-                                   }
-                        (newAppState, result) <- runMethodResponse (m params) reqID mctx initAppState
-                        sid' <- saveNewAppState state newAppState
-                        return $ addStateID sid' result
-           respond (JSON.encode response)
-    Just (Query, m) -> do
-      withRequestID $ \reqID ->
-        do stateID <- getStateID req
-           response <- withMVar theState $
-             \state -> do
-               getAppState state stateID >>=
-                 \case
-                   Nothing -> throwIO $ unknownStateID stateID
-                   Just theAppState ->
-                     do let mctx = MethodContext
-                                   { mctxOptions = opts
-                                   , mctxFileReader = B.readFile -- No caching of this state
-                                   , mctxStatePin = pinAppState state
-                                   , mctxStateUnpin = unpinAppState state
-                                   , mctxStateUnpinAll = clearPersistentCache state
-                                   , mctxSetECacheLimit = setEphemeralCacheLimit state
-                                   }
-                        (_, result) <- runMethodResponse (m params) reqID mctx theAppState
-                        -- Here, we return the original state ID, because
-                        -- queries don't result in new states.
-                        return $ addStateID stateID result
-           respond (JSON.encode response)
-    Just (Notification, m) -> do
-      withoutRequestID $
-       void $
-        do stateID <- getStateID req
-           withMVar theState $
-             \state -> do
-               getAppState state stateID >>=
-                 \case
-                   Nothing -> throwIO $ unknownStateID stateID
-                   Just theAppState ->
-                     -- No reply will be sent, so there is no way of the
-                     -- client re-using any resulting state. So we don't
-                     -- cache file contents here.
-                     let mctx = MethodContext
-                                { mctxOptions = opts
-                                , mctxFileReader = B.readFile -- No caching of this state
-                                , mctxStatePin = pinAppState state
-                                , mctxStateUnpin = unpinAppState state
-                                , mctxStateUnpinAll = clearPersistentCache state
-                                , mctxSetECacheLimit = setEphemeralCacheLimit state
-                                }
-                     in (,()) <$> execMethodSilently (m params) mctx theAppState
+    Just (CommandMethod m) -> withRequestID $ \reqID -> do
+      stateID <- getStateID req
+      response <- withMVar theState $ \state -> do
+        when (stateID == initialStateID) $ do
+          stateCount <- statePoolCount state
+          when (stateCount >= (optMaxOccupancy opts)) $
+            throwIO serverAtCapacity
+        getAppState state stateID >>=
+          \case
+            Nothing -> throwIO $ unknownStateID stateID
+            Just appState -> do
+              let cctx = CommandContext
+                          { cmdCtxMOptions = opts
+                          , cmdCtxFileReader = B.readFile
+                          }
+              let cmd = commandImplementation m
+              (newAppState, result) <- execCommand (cmd params) reqID cctx appState
+              sid' <- nextAppState state stateID newAppState
+              return $ addStateID sid' result
+      respond (JSON.encode response)
+    Just (NotificationMethod m) ->
+      withoutRequestID $ withoutStateID $ do
+        withMVar theState $ \state ->
+          let nctx = NotificationContext
+                      { ntfCtxMOptions = opts
+                      , ntfCtxFileReader = B.readFile
+                      , ntfCtxDestroyState = destroyAppState state
+                      , ntfCtxDestroyAllStates = destroyAllAppStates state
+                      }
+              notify = notificationImplementation m
+          in execNotification (notify params) nctx
   where
-    method   = view requestMethod req
-    params   = JSON.Object $ view requestParams req
-    reqID    = view requestID req
-    theState = view serverState app
+    method   = requestMethod req
+    params   = JSON.Object $ requestParams req
+    reqID    = requestID req
+    theState = serverState app
 
     addStateID :: StateID -> Response anyOldStateID a -> Response StateID a
-    addStateID sid answer =
-      set responseStateID sid answer
+    addStateID sid answer = answer {responseStateID = sid}
 
     withRequestID :: (RequestID -> IO a) -> IO a
     withRequestID act =
@@ -756,6 +749,12 @@ handleRequest opts respond app req =
 
     requireID   = maybe (throwIO invalidRequest) return reqID
     requireNoID = maybe (return ()) (const (throwIO invalidRequest)) reqID
+
+    withoutStateID :: IO a -> IO a
+    withoutStateID act =
+      if HM.member "state" (requestParams req)
+      then throwIO unexpectedStateID
+      else act
 
 
 -- | Given an IO action, return an atomic-ified version of that same action,
@@ -775,7 +774,7 @@ serveStdIO opts = serveHandles opts stdin stdout
 
 getStateID :: Request -> IO StateID
 getStateID req =
-  case view (requestParams . at "state") req of
+  case HM.lookup "state" (requestParams req) of
     Just sid ->
       case JSON.fromJSON sid of
         JSON.Success i -> pure i
@@ -784,8 +783,7 @@ getStateID req =
   where
     noStateID msg =
       throwIO $
-        invalidParams msg $ JSON.Object $ view requestParams req
-
+        invalidParams msg $ JSON.Object $ requestParams req
 
 -- | Serve an application, listening for input on one handle and
 -- sending output to another. Each request must be on a line for

--- a/argo/src/Argo/DefaultMain.hs
+++ b/argo/src/Argo/DefaultMain.hs
@@ -6,10 +6,10 @@ module Argo.DefaultMain
     UserOptions(..),
     userOptions) where
 
-import Control.Applicative
-import Control.Monad
-import Data.Maybe
-import Data.Foldable
+import Control.Applicative ( Alternative((<|>)), (<**>) )
+import Control.Monad ( when )
+import Data.Maybe ( fromMaybe, isJust )
+import Data.Foldable ( for_ )
 import qualified Data.Text.IO as T
 import Control.Concurrent.Async (wait)
 import Control.Exception (handle, IOException)
@@ -19,8 +19,17 @@ import qualified Options.Applicative as Opt
 import Safe (readMay)
 import System.IO (BufferMode(..), hSetBuffering, stderr, stdout)
 import System.FileLock
+    ( lockFile,
+      tryLockFile,
+      unlockFile,
+      withTryFileLock,
+      SharedExclusive(Exclusive) )
 import System.Directory
-import System.FilePath
+    ( createDirectoryIfMissing,
+      getAppUserDataDirectory,
+      listDirectory,
+      removeFile )
+import System.FilePath ( (-<.>), (<.>), (</>), isExtensionOf )
 import System.Exit (die)
 
 import Argo
@@ -110,7 +119,6 @@ data ProgramMode stdioOpts socketOpts httpOpts docOpts
 data GlobalOptions stdioOpts socketOpts httpOpts docOpts =
     GlobalOptions
     { methodOpts :: MethodOptions
-     -- ^ Max number of live concurrent states the server supports.
     , programMode :: ProgramMode stdioOpts socketOpts httpOpts docOpts
     }
 

--- a/argo/src/Argo/DefaultMain.hs
+++ b/argo/src/Argo/DefaultMain.hs
@@ -8,13 +8,13 @@ module Argo.DefaultMain
 
 import Control.Applicative
 import Control.Monad
-import Control.Lens (view)
 import Data.Maybe
 import Data.Foldable
 import qualified Data.Text.IO as T
 import Control.Concurrent.Async (wait)
 import Control.Exception (handle, IOException)
 import Network.Socket (HostName)
+import Numeric.Natural ( Natural )
 import qualified Options.Applicative as Opt
 import Safe (readMay)
 import System.IO (BufferMode(..), hSetBuffering, stderr, stdout)
@@ -110,15 +110,17 @@ data ProgramMode stdioOpts socketOpts httpOpts docOpts
 data GlobalOptions stdioOpts socketOpts httpOpts docOpts =
     GlobalOptions
     { methodOpts :: MethodOptions
+     -- ^ Max number of live concurrent states the server supports.
     , programMode :: ProgramMode stdioOpts socketOpts httpOpts docOpts
     }
 
 mkGlobalOptions ::
   Maybe LogOption ->
   FileSystemMode ->
+  Natural {- ^ max occupancy -} ->
   ProgramMode stdioOpts socketOpts httpOpts docOpts ->
   GlobalOptions stdioOpts socketOpts httpOpts docOpts
-mkGlobalOptions logging fsMode progMode =
+mkGlobalOptions logging fsMode occupancy progMode =
   GlobalOptions
   { methodOpts = defaultMethodOptions {
                    optFileSystemMode = fsMode
@@ -126,6 +128,7 @@ mkGlobalOptions logging fsMode progMode =
                      case logging of
                        Just StdErrLog -> T.hPutStrLn stderr
                        _ -> const (return ())
+                 , optMaxOccupancy = occupancy
                  }
   , programMode = progMode
   }
@@ -188,6 +191,7 @@ allOptions stdioOpts socketOpts httpOpts docOpts desc =
   mkGlobalOptions <$>
   logOpt <*>
   readOnlyOpt <*>
+  maxOccupancyOpt <*>
   (mode stdioOpts socketOpts httpOpts docOpts desc <**> Opt.helper)
 
 options ::
@@ -247,6 +251,14 @@ readOnlyOpt =
   (Opt.flag ReadWrite ReadOnly
    (Opt.long "read-only" <>
     Opt.help "Do not generate any output files, for use on a read-only file system."))
+
+maxOccupancyOpt :: Opt.Parser Natural
+maxOccupancyOpt =
+  (Opt.option Opt.auto
+   (Opt.long "max-occupancy" <>
+    Opt.help "Maximum number of active sessions allowed at once." <>
+    Opt.showDefault <>
+    Opt.value 10))
 
 selectHost :: Maybe HostName -> HostName
 selectHost (Just name) = name
@@ -373,5 +385,5 @@ realMain makeApp globalOpts =
           do theApp <- makeApp (DocOpts userOpts)
              T.putStrLn $
                restructuredText $
-                 Doc.App (view appName theApp) (protocolDocs : view appDocumentation theApp)
+                 Doc.App (appName theApp) (protocolDocs : appDocumentation theApp)
   where opts = methodOpts globalOpts

--- a/argo/src/Argo/ServerState.hs
+++ b/argo/src/Argo/ServerState.hs
@@ -82,9 +82,8 @@ instance JSON.FromJSON StateID where
 
 newtype FileHash = FileHash ByteString deriving (Eq, Ord, Show, Hashable)
 
--- | Given a fresh application state, save it to the (ephemeral)
---   cache and return a fresh state ID that uniquely describes the
---   resulting state.
+-- | Given a fresh application state, return a fresh state
+-- ID that uniquely describes it.
 saveNewAppState ::
   ServerState appState ->
   appState {-^ The new application state -} ->

--- a/argo/src/Argo/ServerState.hs
+++ b/argo/src/Argo/ServerState.hs
@@ -7,43 +7,28 @@ module Argo.ServerState (
   -- * The server's state, which wraps app states
   ServerState,
   initServerState,
-  saveNewAppState,
+  nextAppState,
+  getAppState,
+  destroyAppState,
+  destroyAllAppStates,
+  statePoolCount,
   -- * Server launch options
-  ServerOpts, defaultServerOpts, optEphemeralCacheLimit,
-  -- * File reader with caching
-  freshStateFileReader,
-  -- * Lookup operations
-  getFile, getAppState,
+  StateMutability(..),
   -- * Identifiers for states
   StateID, initialStateID,
-  -- * Server state/cache management
-  pinAppState, unpinAppState,
-  clearPersistentCache, setEphemeralCacheLimit,
-  ephemeralCacheMembers, persistentCacheMembers
   ) where
 
-import Control.Lens
-import Control.Monad (forM_)
+import Numeric.Natural ( Natural )
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as B
 import Data.Hashable (Hashable(..))
 import Data.HashMap.Strict (HashMap)
-import Data.List (sortOn)
-import Data.Set (Set)
-import qualified Data.Set as Set
-import Data.Time.Clock (UTCTime, getCurrentTime)
 import qualified Data.HashMap.Strict as HM
 import qualified Data.Aeson as JSON
 import Data.IORef
 import Data.UUID (UUID)
 import qualified Data.UUID as UUID
 import qualified Data.UUID.V4 as UUID
-
-import Argo.Panic
-
-import GHC.IO.Exception
-
-import qualified Crypto.Hash.SHA1 as SHA1 (hash)
 
 -- | A representation of protocol states to be exchanged with clients
 data StateID = InitialStateID | StateID UUID
@@ -80,159 +65,18 @@ instance JSON.FromJSON StateID where
              Nothing -> mempty
              Just uuid -> pure (StateID uuid)
 
-newtype FileHash = FileHash ByteString deriving (Eq, Ord, Show, Hashable)
-
--- | Given a fresh application state, return a fresh state
--- ID that uniquely describes it.
-saveNewAppState ::
-  ServerState appState ->
-  appState {-^ The new application state -} ->
-  IO StateID
-saveNewAppState server newAppState =
-  do uuid <- UUID.nextRandom
-     now <- getCurrentTime
-     let cas = CachedAppState
-               { casState = newAppState
-               , casFiles = HM.empty
-               , casLastUsed = now
-               }
-     enforceCacheLimit server
-     modifyIORef' (view ephemeralStateCache server) $ HM.insert uuid cas
-     return $ StateID uuid
-
-
--- If we are at or over capacity, remove the oldest item(s)
--- from the ephemeral cache until we are at half capacity.
-enforceCacheLimit :: ServerState s -> IO ()
-enforceCacheLimit server = do
-  maxSize <- readIORef (view ephemeralStateCacheLimit server)
-  curSize <- HM.size <$> readIORef (view ephemeralStateCache server)
-  if (curSize >= maxSize) then do
-    entries <- HM.toList <$> readIORef (view ephemeralStateCache server)
-    -- Remove at least one, remove enough to get under max size, and
-    -- remove some extra to keep us under the cap for a bit if possible.
-    let n = max 1 $ max (curSize - maxSize) (maxSize `div` 2)
-    let extras = take n $ sortOn (casLastUsed . snd) entries
-    forM_ extras $ \(uuid, cas) -> do
-      -- Remove the state from the ephemeral cache.
-      modifyIORef' (view ephemeralStateCache server) $ HM.delete uuid
-      -- Decrement the reference tracking sets for the cached files.
-      mapM_ (removeRefToFile uuid) $ casFiles cas
-  else pure ()
-
- where
-    -- Update the cached file corresponding to @fHash@ so it no longer thinks it
-    -- is referred to by @uuid@.
-    removeRefToFile :: UUID -> FileHash -> IO ()
-    removeRefToFile uuid fHash = do
-      (HM.lookup fHash <$> (readIORef (view cachedFiles server))) >>=
-        \case
-          Nothing -> pure ()
-          Just cf -> do
-            let states = Set.delete (StateID uuid) (cfStates cf)
-            if Set.null states
-            then modifyIORef' (view cachedFiles server) $ HM.delete fHash
-            else modifyIORef' (view cachedFiles server) $ HM.insert fHash (cf {cfStates = states})
 
 
 
--- | Read a file and its hash simultaneously
-readWithHash :: FilePath -> IO (ByteString, FileHash)
-readWithHash file =
-  do contents <- B.readFile file
-     let fileHash = FileHash $! SHA1.hash contents
-     return (contents, fileHash)
+-- | Describes whether the application state is pure or mutable.
+data StateMutability
+  = PureState
+  | MutableState
 
--- | A file reading operation that should be used to read a file
--- for the first time for a state (i.e., when the state is
--- fresh and is being constructed for the first time rather than
--- when the client has sent its ID). This is intended to be 
--- applied to its first two arguments by the server, and
--- supplied to an app as a @FilePath -> IO ByteString@.
-freshStateFileReader ::
-  ServerState s -> StateID -> FilePath -> IO ByteString
-freshStateFileReader server sid fileName = do
-  let cFilesRef = view cachedFiles server
-  (contents, fileHash) <- readWithHash fileName
-  -- Update the cached files map as appropriate.
-  (HM.lookup fileHash <$> (readIORef cFilesRef)) >>=
-    \case
-      Just _ -> do
-        -- We have _already_ seen this file before! Add this `sid` to the set
-        -- of states which refer to this file.
-        let updateCF = \cf -> cf {cfStates = Set.insert sid (cfStates cf)}
-        modifyIORef' cFilesRef $ HM.adjust updateCF fileHash
-      Nothing -> do
-        -- We have _not_ seen this file before. Add it to the cached files.
-        modifyIORef' cFilesRef $ 
-          HM.insert fileHash (CachedFile contents (Set.singleton sid))
-  -- Find and update the cached app state.
-  case sid of
-    InitialStateID -> do
-      modifyIORef' (view cachedInitState server) $ 
-        \cas -> cas {casFiles = HM.insert fileName fileHash (casFiles cas)}
-    StateID uuid -> do
-      (cas, casCacheRef) <- do
-        (HM.lookup uuid <$> readIORef (view ephemeralStateCache server)) >>=
-         \case
-           Just cas -> pure (cas, (view ephemeralStateCache server))
-           Nothing -> do
-             (HM.lookup uuid <$> readIORef (view persistentStateCache server)) >>=
-              \case
-                Just cas -> pure (cas, (view persistentStateCache server))
-                Nothing -> panic "readAndCacheFileForState" ["State ID not found: " ++ (show uuid)]
-      let cas' = cas {casFiles = HM.insert fileName fileHash (casFiles cas)}
-      modifyIORef' casCacheRef $ HM.insert uuid cas'
-  pure contents
-
-
-data CachedFile =
-  CachedFile
-  { cfContents :: !ByteString
-  -- ^ File Contents
-  , cfStates :: !(Set StateID)
-    -- ^ States referring to this file.
-  }
-
-data CachedAppState s =
-  CachedAppState
-  { casState :: !s
-  -- ^ The cached app state itself.  
-  , casFiles :: !(HashMap FilePath FileHash)
-  -- ^ Files this state relies on.
-  , casLastUsed :: !UTCTime
-  -- ^ When this state last involved in a server request.
-  }
-
--- | Options affecting how the server initial settings at launch.
-data ServerOpts =
-  ServerOpts
-  {
-    initEphemeralStateCacheLimit :: !Int
-  }
-
--- | Generic server options, including the following:
---   * Ephemeral cache size (see @optEphemeralCacheLimit@, default is @10@.)
-defaultServerOpts :: ServerOpts
-defaultServerOpts =
-  ServerOpts
-  {
-    initEphemeralStateCacheLimit = 10
-  }
-
--- | Updates the size of the ephemeral state cache for a @ServerOpts@,
--- i.e., how many non-pinned, non-initial states are kept alive by
--- the server. When the limit is reached, half of the ephemeral states
--- (the oldest) are purged from the cache and are no longer available
--- for server requests.
-optEphemeralCacheLimit ::
-  Int ->
-  ServerOpts ->
-  ServerOpts
-optEphemeralCacheLimit sz opts =
-  opts {
-          initEphemeralStateCacheLimit = sz
-       }
+-- | How the initial app state is stored, based on the state's mutability.
+data InitialAppState appState
+  = PureInitState appState
+  | MutableInitState (() -> IO appState)
 
 
 -- | @ServerState@s contain cached application states and manage state
@@ -240,263 +84,77 @@ optEphemeralCacheLimit sz opts =
 -- prevent the 'IORef's from being mutated inconsistently.
 data ServerState appState =
   ServerState
-  { _cachedInitState :: !(IORef (CachedAppState appState))
-  -- State entered when server is started (is retained indefinitely).
-  , _cachedFiles :: !(IORef (HashMap FileHash CachedFile))
-    -- ^ Cache of loaded files (allows for sharing and tracking usage).
-    --   N.B., cached files should be updated and possibly purged by Argo
-    --   as states that refer to them are purged (see @cachedFileStates@
-    --   field of @CachedFile@).
-  , _ephemeralStateCache :: !(IORef (HashMap UUID (CachedAppState appState)))
-    -- ^ Live application states which are subject to being purged.
-  , _persistentStateCache :: !(IORef (HashMap UUID (CachedAppState appState)))
-    -- ^ Live application states which are retained until otherwise directed.
-  , _ephemeralStateCacheLimit :: !(IORef Int)
-  -- ^ Maximum number of application states to keep live in the ephemeral cache.
+  { serverInitAppState :: !(InitialAppState appState)
+  -- ^ State entered when server is started.
+  , serverStatePool :: !(IORef (HashMap UUID appState))
+  -- ^ Currently active states.
   }
-
--- | A lens into the cached initial server state
-cachedInitState :: Lens' (ServerState appState) (IORef (CachedAppState appState))
-cachedInitState = lens _cachedInitState (\s is -> s { _cachedInitState = is })
-
--- | A lens into the cache of files used by in-cache states.
-cachedFiles :: Lens' (ServerState appState) (IORef (HashMap FileHash CachedFile))
-cachedFiles = lens _cachedFiles (\s fs -> s { _cachedFiles = fs })
-
--- | A lens into the server's ephemoral cached application states.
-ephemeralStateCache :: Lens' (ServerState appState) (IORef (HashMap UUID (CachedAppState appState)))
-ephemeralStateCache = lens _ephemeralStateCache (\s c -> s { _ephemeralStateCache = c })
-
-
--- | A lens into the server's persistent cached application states.
-persistentStateCache :: Lens' (ServerState appState) (IORef (HashMap UUID (CachedAppState appState)))
-persistentStateCache = lens _persistentStateCache (\s c -> s { _persistentStateCache = c })
-
--- | A lens to the maximum number of states to keep in cache (if one exists).
-ephemeralStateCacheLimit :: Lens' (ServerState appState) (IORef Int)
-ephemeralStateCacheLimit = lens _ephemeralStateCacheLimit (\s sz -> s { _ephemeralStateCacheLimit = sz })
 
 
 -- | Construct an initial server state, given a means of constructing
 -- the initial application state and a bound on the number of states 
 -- to keep cached.
---
--- The initial application state is associated with the empty recipe
--- @[]@ and the initial 'StateID'.
 initServerState ::
-  ServerOpts ->
+  StateMutability ->
   ((FilePath -> IO ByteString) -> IO appState) ->
   IO (ServerState appState)
-initServerState opts mkInitState =
-  do fileCache <- newIORef HM.empty
-     eStateCache <- newIORef $ HM.empty
-     pStateCache <- newIORef $ HM.empty
-     eLimit <- newIORef (initEphemeralStateCacheLimit opts)
-     initStateFiles <- newIORef $ HM.empty
-     s <- mkInitState $ initFileReader fileCache initStateFiles
-     sFiles <- readIORef initStateFiles
-     now <- getCurrentTime
-     cInitState <- newIORef $ CachedAppState s sFiles now
-     pure $
-       ServerState
-       { _cachedInitState = cInitState
-       , _cachedFiles = fileCache
-       , _ephemeralStateCache = eStateCache
-       , _persistentStateCache = pStateCache
-       , _ephemeralStateCacheLimit = eLimit
-       }
-  where
-    initFileReader :: IORef (HashMap FileHash CachedFile) -> 
-                      IORef (HashMap FilePath FileHash) ->
-                      FilePath ->
-                      IO ByteString
-    initFileReader fileCache initStateFiles path =
-      do (contents, fileHash) <- readWithHash path
-         modifyIORef' fileCache $ HM.insert fileHash (CachedFile contents (Set.singleton initialStateID))
-         (HM.lookup path <$> readIORef initStateFiles) >>=
-          \case
-            -- We haven't seen this file before during initial state creation, so just add it
-            -- and it's content to the hash maps.
-            Nothing -> do
-              modifyIORef' initStateFiles $ HM.insert path fileHash
-            -- They read the same file twice while creating the initial state and the contents
-            -- did not change... do nothing since we've already cached the contents.
-            Just prevHash | prevHash == fileHash -> pure ()
-            -- They've re-read this file but the contents are now different. Remove the old cached
-            -- contents (since we identify files uniquely by state and filepath) and log
-            -- the new one..
-            Just prevHash -> do
-              modifyIORef' fileCache $ HM.delete prevHash
-              modifyIORef' initStateFiles $ HM.insert path fileHash
-         pure contents
+initServerState mut mkInitState = do
+  initState <- case mut of
+    PureState -> PureInitState <$> (mkInitState B.readFile)
+    MutableState -> pure $ MutableInitState $ \_ -> mkInitState $ B.readFile
+  emptyStatePool <- newIORef HM.empty
+  pure $
+    ServerState
+    { serverInitAppState = initState
+    , serverStatePool = emptyStatePool
+    }
 
+statePoolCount :: ServerState appState -> IO Natural
+statePoolCount server =
+  fromInteger . toInteger . HM.size <$> readIORef (serverStatePool server)
 
--- | Lookup a @CachedAppState@ (whether it's cached ephemerally or
---   persistently) and update it's last used timestamp.
-getCachedAppState :: 
-  ServerState s ->
-  StateID ->
-  IO (Maybe (CachedAppState s))
-getCachedAppState server InitialStateID = do
-  s <- readIORef $ view cachedInitState server
-  pure $ Just s
-getCachedAppState server (StateID uuid) = do
-  (HM.lookup uuid <$> (readIORef $ view ephemeralStateCache server)) >>=
-    \case
-      Just cas -> do
-        now <- getCurrentTime
-        modifyIORef' (view ephemeralStateCache server) $ HM.insert uuid (cas {casLastUsed = now})
-        pure $ Just cas
-      Nothing -> do
-        (HM.lookup uuid <$> (readIORef $ view persistentStateCache server)) >>=
-          \case
-            Just cas -> do
-              now <- getCurrentTime
-              modifyIORef' (view persistentStateCache server) $ HM.insert uuid (cas {casLastUsed = now})
-              pure $ Just cas
-            Nothing -> pure Nothing
+-- | Given a fresh application state and the StateID it was derived from,
+-- return a fresh state ID that uniquely describes the new state and
+-- destroy the previous state (if possible).
+nextAppState ::
+  ServerState appState ->
+  StateID {-^ State ID from which the new state originated (i.e., its parent) -} ->
+  appState {-^ The new application state -} ->
+  IO StateID
+nextAppState server prevStateID newAppState = do
+  destroyAppState server prevStateID
+  uuid <- UUID.nextRandom
+  modifyIORef' (serverStatePool server) $ HM.insert uuid newAppState
+  return $ StateID uuid
 
-
--- | Retrieve the contents of a file as they were in a particular state.
-getFile ::
+-- | Desctroy an app state so it is no longer available for requests.
+destroyAppState ::
   ServerState appState ->
   StateID ->
-  FilePath -> IO ByteString
-getFile server sid filename = do
-  sFiles <- getCachedAppState server sid >>=
-              \case
-                 Nothing -> raiseNoSuchState
-                 Just cState -> pure $ casFiles cState
-  fHash <- case HM.lookup filename sFiles of
-             Nothing -> raiseNoSuchFile
-             Just fileHash -> pure fileHash
-  (HM.lookup fHash <$> readIORef (view cachedFiles server)) >>=
-    \case
-       Nothing -> raiseNoSuchFile
-       Just cf -> pure $ cfContents cf
-  where
-      raiseNoSuchFile =
-        ioError $
-         IOError { ioe_handle = Nothing
-                 , ioe_type = NoSuchThing
-                 , ioe_location = "restoring " ++ filename
-                 , ioe_description = "No such cached file " ++ filename
-                 , ioe_errno = Nothing
-                 , ioe_filename = Just filename
-                 }
-      raiseNoSuchState =
-        ioError $
-         IOError { ioe_handle = Nothing
-                 , ioe_type = NoSuchThing
-                 , ioe_location = "restoring " ++ filename ++ " in state " ++ (show sid)
-                 , ioe_description = "No such state currently cached " ++ (show sid)
-                 , ioe_errno = Nothing
-                 , ioe_filename = Just filename
-                 }
+  IO ()
+destroyAppState _server InitialStateID = pure ()
+destroyAppState server (StateID uuid) = modifyIORef' (serverStatePool server) $ HM.delete uuid
 
-
+-- | Destroy all app states so they are no longer available for requests.
+destroyAllAppStates ::
+  ServerState appState ->
+  IO ()
+destroyAllAppStates server = writeIORef (serverStatePool server) $ HM.empty
 
 -- | Retrieve the application state that corresponds to a given state ID.
+--
+--   If given the initial state ID and the server state is mutable,
+--   a new initial state will be returned.
 --
 -- If the state ID is not known, returns Nothing.
 getAppState ::
   ServerState appState ->
   StateID ->
   IO (Maybe appState)
-getAppState server sid = do
-  mCAS <- getCachedAppState server sid
-  pure $ casState <$> mCAS
-
-
--- | Ensure a currently visible state remains visible/in-cache
--- until explicitly unpinned.
-pinAppState ::
-  ServerState appState ->
-  StateID ->
-  IO ()
-pinAppState _server InitialStateID = pure ()
-pinAppState server (StateID uuid) =
-  (HM.lookup uuid <$> readIORef (view ephemeralStateCache server)) >>=
-    \case
-      Just cas -> do
-        -- Move it from the ephemeral to the persistent cache.
-        now <- getCurrentTime
-        modifyIORef' (view ephemeralStateCache server) $ HM.delete uuid
-        modifyIORef' (view persistentStateCache server) $ HM.insert uuid (cas {casLastUsed = now})
-      Nothing -> do
-        -- We didn't see it in the ephemeral cache... let's see if it's already in the persistent cache.
-        (HM.lookup uuid <$> readIORef (view persistentStateCache server)) >>=
-          \case
-            Just cas -> do
-              -- Let's just update the last used time.
-              now <- getCurrentTime
-              modifyIORef' (view persistentStateCache server) $ HM.insert uuid (cas {casLastUsed = now})
-            Nothing -> do
-              -- We didn't see it in either cache... uh oh
-              ioError $
-                IOError { ioe_handle = Nothing
-                        , ioe_type = NoSuchThing
-                        , ioe_location = "pinning state " ++ (show uuid)
-                        , ioe_description = "No such state currently cached " ++ (show uuid)
-                        , ioe_errno = Nothing
-                        , ioe_filename = Nothing
-                        }
-
-
--- Like unpinAppState but takes a UUID and performs no cache flushing.
-internalUnpinAppState ::
-  ServerState appState ->
-  UUID ->
-  IO ()
-internalUnpinAppState server uuid =
-  (HM.lookup uuid <$> readIORef (view persistentStateCache server)) >>=
-    \case
-      Just cas -> do
-        modifyIORef' (view ephemeralStateCache server) $ HM.insert uuid cas
-        modifyIORef' (view persistentStateCache server) $ HM.delete uuid
-      Nothing -> pure ()
-
-
--- | Unpin a cached state (a noop if the state is not found in the persistent cache).
-unpinAppState ::
-  ServerState appState ->
-  StateID ->
-  IO ()
-unpinAppState _server InitialStateID = pure ()
-unpinAppState server (StateID uuid) = do
-  internalUnpinAppState server uuid
-  enforceCacheLimit server
-
--- | Move states from the persistent cache into the ephemeral cache
--- and empty old states from the cache if necessary.
-clearPersistentCache ::
-  ServerState appState ->
-  IO ()
-clearPersistentCache server = do
-  pids <- HM.keys <$> readIORef (view persistentStateCache server)
-  mapM_ (internalUnpinAppState server) pids
-  enforceCacheLimit server
-
--- | Change the ephemeral cache limit and clean the cache to meet
--- the new limit if necessary.
-setEphemeralCacheLimit ::
-  ServerState appState ->
-  Int ->
-  IO ()
-setEphemeralCacheLimit server sz = do
-  writeIORef (view ephemeralStateCacheLimit server) (max sz 1)
-  enforceCacheLimit server
-
--- | Return the keys in the ephemeral cache.
-ephemeralCacheMembers ::
-  ServerState appState ->
-  IO [UUID]
-ephemeralCacheMembers server =
-  HM.keys <$> readIORef (view ephemeralStateCache server)
-
--- | Return the keys in the persistent cache.
-persistentCacheMembers ::
-  ServerState appState ->
-  IO [UUID]
-persistentCacheMembers server =
-  HM.keys <$> readIORef (view persistentStateCache server)
+getAppState server InitialStateID =
+  case (serverInitAppState server) of
+    PureInitState s -> pure $ Just s
+    MutableInitState f -> Just <$> f ()
+getAppState server (StateID uuid) = do
+  pool <- readIORef (serverStatePool server)
+  pure $ (HM.lookup uuid pool)

--- a/file-echo-api/file-echo-api.cabal
+++ b/file-echo-api/file-echo-api.cabal
@@ -12,7 +12,7 @@ data-files:          test-scripts/**/*.py
 
 common warnings
   ghc-options:
-    -Weverything
+    -Wall
     -Wno-missing-exported-signatures
     -Wno-missing-import-lists
     -Wno-missed-specialisations
@@ -47,12 +47,19 @@ library
   hs-source-dirs:      src
 
   exposed-modules:
-    FileEchoServer
+    FileEchoServer,
+    MutableFileEchoServer
 
 executable file-echo-api
   import:              deps, warnings
   main-is:             Main.hs
   hs-source-dirs:      file-echo-api
+  build-depends:
+    file-echo-api
 
+executable mutable-file-echo-api
+  import:              deps, warnings
+  main-is:             Main.hs
+  hs-source-dirs:      mutable-file-echo-api
   build-depends:
     file-echo-api

--- a/file-echo-api/file-echo-api/Main.hs
+++ b/file-echo-api/file-echo-api/Main.hs
@@ -58,9 +58,9 @@ serverMethods =
   , Argo.command "clear" (Doc.Paragraph [Doc.Text "Forget the loaded file."]) FES.clearCmd
   , Argo.command "prepend" (Doc.Paragraph [Doc.Text "Append a string to the left of the current contents."]) FES.prependCmd
   , Argo.command "drop" (Doc.Paragraph [Doc.Text "Drop from the left of the current contents."]) FES.dropCmd
-  , Argo.command "implode" (Doc.Paragraph [Doc.Text "Throw an error immediately."]) FES.implodeCmd
-  , Argo.command "show" (Doc.Paragraph [Doc.Text "Show a substring of the file."]) FES.showCmd
-  , Argo.command "ignore" (Doc.Paragraph [Doc.Text "Ignore an ", Doc.Link (Doc.TypeDesc (typeRep (Proxy @FES.Ignorable))) "ignorable value", Doc.Text "."]) FES.ignoreCmd
+  , Argo.query "implode" (Doc.Paragraph [Doc.Text "Throw an error immediately."]) FES.implodeCmd
+  , Argo.query "show" (Doc.Paragraph [Doc.Text "Show a substring of the file."]) FES.showCmd
+  , Argo.query "ignore" (Doc.Paragraph [Doc.Text "Ignore an ", Doc.Link (Doc.TypeDesc (typeRep (Proxy @FES.Ignorable))) "ignorable value", Doc.Text "."]) FES.ignoreCmd
   , Argo.notification "destroy state" (Doc.Paragraph [Doc.Text "Destroy a state in the server."]) FES.destroyState
   , Argo.notification "destroy all states" (Doc.Paragraph [Doc.Text "Destroy all states in the server."]) FES.destroyAllStates
   ]

--- a/file-echo-api/file-echo-api/Main.hs
+++ b/file-echo-api/file-echo-api/Main.hs
@@ -18,7 +18,12 @@ main :: IO ()
 main = customMain parseServerOptions parseServerOptions parseServerOptions parseServerOptions description getApp
   where
     getApp opts =
-      Argo.mkDefaultApp "file-echo-api" docs (mkInitState $ userOptions opts) serverMethods
+      Argo.mkApp
+        "file-echo-api"
+        docs
+        (Argo.defaultAppOpts Argo.PureState)
+        (mkInitState $ userOptions opts)
+        serverMethods
 
 docs :: [Doc.Block]
 docs =
@@ -49,15 +54,13 @@ parseServerOptions = ServerOptions <$> filename
 
 serverMethods :: [Argo.AppMethod FES.ServerState]
 serverMethods =
-  [ Argo.method "load" Argo.Command (Doc.Paragraph [Doc.Text "Load a file from disk into memory."]) FES.loadCmd
-  , Argo.method "clear" Argo.Command (Doc.Paragraph [Doc.Text "Forget the loaded file."]) FES.clearCmd
-  , Argo.method "prepend" Argo.Command (Doc.Paragraph [Doc.Text "Append a string to the left of the current contents."]) FES.prependCmd
-  , Argo.method "drop" Argo.Command (Doc.Paragraph [Doc.Text "Drop from the left of the current contents."]) FES.dropCmd
-  , Argo.method "implode" Argo.Query (Doc.Paragraph [Doc.Text "Throw an error immediately."]) FES.implodeCmd
-  , Argo.method "show" Argo.Query (Doc.Paragraph [Doc.Text "Show a substring of the file."]) FES.showCmd
-  , Argo.method "ignore" Argo.Query (Doc.Paragraph [Doc.Text "Ignore an ", Doc.Link (Doc.TypeDesc (typeRep (Proxy @FES.Ignorable))) "ignorable value", Doc.Text "."]) FES.ignoreCmd
-  , Argo.method "pin state" Argo.Notification (Doc.Paragraph [Doc.Text "Pins a state in the server so it is available until unpinned."]) FES.pinState
-  , Argo.method "unpin state" Argo.Notification (Doc.Paragraph [Doc.Text "Unpins a state in the server."]) FES.unpinState
-  , Argo.method "unpin all states" Argo.Notification (Doc.Paragraph [Doc.Text "Unpin all states in the server."]) FES.unpinAllStates
-  , Argo.method "set cache limit" Argo.Notification (Doc.Paragraph [Doc.Text "Unpin all states in the server."]) FES.setCacheLimit
+  [ Argo.command "load" (Doc.Paragraph [Doc.Text "Load a file from disk into memory."]) FES.loadCmd
+  , Argo.command "clear" (Doc.Paragraph [Doc.Text "Forget the loaded file."]) FES.clearCmd
+  , Argo.command "prepend" (Doc.Paragraph [Doc.Text "Append a string to the left of the current contents."]) FES.prependCmd
+  , Argo.command "drop" (Doc.Paragraph [Doc.Text "Drop from the left of the current contents."]) FES.dropCmd
+  , Argo.command "implode" (Doc.Paragraph [Doc.Text "Throw an error immediately."]) FES.implodeCmd
+  , Argo.command "show" (Doc.Paragraph [Doc.Text "Show a substring of the file."]) FES.showCmd
+  , Argo.command "ignore" (Doc.Paragraph [Doc.Text "Ignore an ", Doc.Link (Doc.TypeDesc (typeRep (Proxy @FES.Ignorable))) "ignorable value", Doc.Text "."]) FES.ignoreCmd
+  , Argo.notification "destroy state" (Doc.Paragraph [Doc.Text "Destroy a state in the server."]) FES.destroyState
+  , Argo.notification "destroy all states" (Doc.Paragraph [Doc.Text "Destroy all states in the server."]) FES.destroyAllStates
   ]

--- a/file-echo-api/mutable-file-echo-api/Main.hs
+++ b/file-echo-api/mutable-file-echo-api/Main.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PartialTypeSignatures #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+module Main ( main ) where
+
+import Data.ByteString (ByteString)
+import Data.Typeable
+import qualified Options.Applicative as Opt
+
+import qualified Argo as Argo
+import qualified Argo.Doc as Doc
+import Argo.DefaultMain ( customMain, userOptions )
+
+import qualified MutableFileEchoServer as MFES
+
+main :: IO ()
+main = customMain parseServerOptions parseServerOptions parseServerOptions parseServerOptions description getApp
+  where
+    getApp opts =
+      Argo.mkDefaultApp "file-echo-api" docs (mkInitState $ userOptions opts) serverMethods
+
+docs :: [Doc.Block]
+docs =
+  [ Doc.Paragraph [Doc.Text "A sample server that demonstrates filesystem caching with a mutable application state."]
+  ]
+
+description :: String
+description =
+  "An RPC server for loading and printing files."
+
+mkInitState :: ServerOptions -> (FilePath -> IO ByteString) -> IO MFES.ServerState
+mkInitState opts reader = MFES.initialState (initialFile opts) reader
+
+newtype ServerOptions = ServerOptions { initialFile :: Maybe FilePath }
+
+-- This function parses additional options used by this particular
+-- application. The ordinary Argo options are still parsed, and these
+-- are appended.
+parseServerOptions :: Opt.Parser ServerOptions
+parseServerOptions = ServerOptions <$> filename
+  where
+    filename =
+      Opt.optional $ Opt.strOption $
+      Opt.long "file" <>
+      Opt.metavar "FILENAME" <>
+      Opt.help "Initial file to echo"
+
+serverMethods :: [Argo.AppMethod MFES.ServerState]
+serverMethods =
+  [ Argo.method "load" Argo.Command (Doc.Paragraph [Doc.Text "Load a file from disk into memory."]) MFES.loadCmd
+  , Argo.method "clear" Argo.Command (Doc.Paragraph [Doc.Text "Forget the loaded file."]) MFES.clearCmd
+  , Argo.method "show" Argo.Query (Doc.Paragraph [Doc.Text "Show a substring of the file."]) MFES.showCmd
+  ]

--- a/file-echo-api/mutable-file-echo-api/Main.hs
+++ b/file-echo-api/mutable-file-echo-api/Main.hs
@@ -5,7 +5,6 @@
 module Main ( main ) where
 
 import Data.ByteString (ByteString)
-import Data.Typeable
 import qualified Options.Applicative as Opt
 
 import qualified Argo as Argo
@@ -18,7 +17,12 @@ main :: IO ()
 main = customMain parseServerOptions parseServerOptions parseServerOptions parseServerOptions description getApp
   where
     getApp opts =
-      Argo.mkDefaultApp "file-echo-api" docs (mkInitState $ userOptions opts) serverMethods
+      Argo.mkApp
+        "mutable-file-echo-api"
+        docs
+        (Argo.defaultAppOpts Argo.MutableState)
+        (mkInitState $ userOptions opts)
+        serverMethods
 
 docs :: [Doc.Block]
 docs =
@@ -48,7 +52,8 @@ parseServerOptions = ServerOptions <$> filename
 
 serverMethods :: [Argo.AppMethod MFES.ServerState]
 serverMethods =
-  [ Argo.method "load" Argo.Command (Doc.Paragraph [Doc.Text "Load a file from disk into memory."]) MFES.loadCmd
-  , Argo.method "clear" Argo.Command (Doc.Paragraph [Doc.Text "Forget the loaded file."]) MFES.clearCmd
-  , Argo.method "show" Argo.Query (Doc.Paragraph [Doc.Text "Show a substring of the file."]) MFES.showCmd
+  [ Argo.command "load" (Doc.Paragraph [Doc.Text "Load a file from disk into memory."]) MFES.loadCmd
+  , Argo.command "clear" (Doc.Paragraph [Doc.Text "Forget the loaded file."]) MFES.clearCmd
+  , Argo.command "show" (Doc.Paragraph [Doc.Text "Show a substring of the file."]) MFES.showCmd
+  , Argo.notification "destroy state" (Doc.Paragraph [Doc.Text "Destroy a state."]) MFES.destroyState
   ]

--- a/file-echo-api/mutable-file-echo-api/Main.hs
+++ b/file-echo-api/mutable-file-echo-api/Main.hs
@@ -54,6 +54,6 @@ serverMethods :: [Argo.AppMethod MFES.ServerState]
 serverMethods =
   [ Argo.command "load" (Doc.Paragraph [Doc.Text "Load a file from disk into memory."]) MFES.loadCmd
   , Argo.command "clear" (Doc.Paragraph [Doc.Text "Forget the loaded file."]) MFES.clearCmd
-  , Argo.command "show" (Doc.Paragraph [Doc.Text "Show a substring of the file."]) MFES.showCmd
+  , Argo.query "show" (Doc.Paragraph [Doc.Text "Show a substring of the file."]) MFES.showCmd
   , Argo.notification "destroy state" (Doc.Paragraph [Doc.Text "Destroy a state."]) MFES.destroyState
   ]

--- a/file-echo-api/src/FileEchoServer.hs
+++ b/file-echo-api/src/FileEchoServer.hs
@@ -40,24 +40,6 @@ newtype ServerCmd a =
 
 
 ------------------------------------------------------------------------
--- Command Execution
-
-runServerCmd :: ServerCmd a -> Argo.Method ServerState a
-runServerCmd (ServerCmd cmd) =
-    do s <- Argo.getState
-       reader <- Argo.getFileReader
-       out <- liftIO $ cmd (reader, fileContents s)
-       case out of
-         ServerRes (Left (ServerErr message)) ->
-           Argo.raise $ Argo.makeJSONRPCException
-            11000 "File Server exception"
-            (Just (JSON.object ["error" .= message]))
-         ServerRes (Right (x, newFileContents)) ->
-           do Argo.setState (s { fileContents = newFileContents})
-              return x
-
-
-------------------------------------------------------------------------
 -- Errors
 
 fileNotFound :: FilePath -> Argo.JSONRPCException
@@ -81,7 +63,7 @@ instance Doc.DescribedParams LoadParams where
     [("file path",
       Doc.Paragraph [Doc.Text "The file to read into memory."])]
 
-loadCmd :: LoadParams -> Argo.Method ServerState ()
+loadCmd :: LoadParams -> Argo.Command ServerState ()
 loadCmd (LoadParams file) =
   do exists <- liftIO $ Dir.doesFileExist file
      if exists
@@ -109,7 +91,7 @@ instance Doc.DescribedParams PrependParams where
     [("content",
       Doc.Paragraph [Doc.Text "The string to append to the left of the current file content on the server."])]
 
-prependCmd :: PrependParams -> Argo.Method ServerState ()
+prependCmd :: PrependParams -> Argo.Command ServerState ()
 prependCmd (PrependParams str) =
   do (FileContents contents) <-  fileContents <$> Argo.getState
      Argo.setState $ ServerState
@@ -132,7 +114,7 @@ instance Doc.DescribedParams DropParams where
     [("count",
       Doc.Paragraph [Doc.Text "The number of characters to drop from the left of the current file content on the server."])]
 
-dropCmd :: DropParams -> Argo.Method ServerState ()
+dropCmd :: DropParams -> Argo.Command ServerState ()
 dropCmd (DropParams n) =
   do (FileContents contents) <-  fileContents <$> Argo.getState
      Argo.setState $ ServerState
@@ -153,7 +135,7 @@ instance JSON.FromJSON ClearParams where
 instance Doc.DescribedParams ClearParams where
   parameterFieldDescription = []
 
-clearCmd :: ClearParams -> Argo.Method ServerState ()
+clearCmd :: ClearParams -> Argo.Command ServerState ()
 clearCmd _ =
   do Argo.setState $ ServerState
       { loadedFile = Nothing
@@ -185,7 +167,7 @@ instance Doc.DescribedParams ShowParams where
                               ]
 
 
-showCmd :: ShowParams -> Argo.Method ServerState JSON.Value
+showCmd :: ShowParams -> Argo.Command ServerState JSON.Value
 showCmd (ShowParams start end) =
   do (FileContents contents) <-  fileContents <$> Argo.getState
      let len = case end of
@@ -208,7 +190,7 @@ instance Doc.DescribedParams ImplodeParams where
   parameterFieldDescription = []
 
 
-implodeCmd :: ClearParams -> Argo.Method ServerState ()
+implodeCmd :: ClearParams -> Argo.Command ServerState ()
 implodeCmd _ = liftIO $ throwIO Argo.internalError
 
 ----------------------------------------------------------------------
@@ -252,92 +234,47 @@ instance Doc.DescribedParams IgnoreParams where
     [("to be ignored",
       Doc.Paragraph [Doc.Text "The value to be ignored goes here."])]
 
-ignoreCmd :: IgnoreParams -> Argo.Method ServerState ()
+ignoreCmd :: IgnoreParams -> Argo.Command ServerState ()
 ignoreCmd _ = pure ()
 
 
-
 ------------------------------------------------------------------------
--- Pin State Command
-data PinStateParams =
-  PinStateParams
+-- Destroy State Command
+data DestroyStateParams =
+  DestroyStateParams
   {
-    stateToPin :: !Argo.StateID
+    stateToDestroy :: !Argo.StateID
   }
 
-instance JSON.FromJSON PinStateParams where
+instance JSON.FromJSON DestroyStateParams where
   parseJSON =
-    JSON.withObject "params for \"pin state\"" $
-    \o -> PinStateParams <$> o .: "state to pin"
+    JSON.withObject "params for \"destroy state\"" $
+    \o -> DestroyStateParams <$> o .: "state to destroy"
 
-instance Doc.DescribedParams PinStateParams where
+instance Doc.DescribedParams DestroyStateParams where
   parameterFieldDescription = 
-    [("state to pin",
-       Doc.Paragraph [Doc.Text "The state to pin in the server so it is available until unpinned."])
+    [("state to destroy",
+       Doc.Paragraph [Doc.Text "The state to destroy in the server (so it can be released from memory)."])
      ]
 
-pinState :: PinStateParams -> Argo.Method ServerState ()
-pinState (PinStateParams stateID) = Argo.pinState stateID
-
-
-------------------------------------------------------------------------
--- Unpin State Command
-data UnpinStateParams =
-  UnpinStateParams
-  {
-    stateToUnpin :: !Argo.StateID
-  }
-
-instance JSON.FromJSON UnpinStateParams where
-  parseJSON =
-    JSON.withObject "params for \"unpin state\"" $
-    \o -> UnpinStateParams <$> o .: "state to unpin"
-
-instance Doc.DescribedParams UnpinStateParams where
-  parameterFieldDescription = 
-    [("state to unpin",
-       Doc.Paragraph [Doc.Text "The state to unpin in the server (so it can be released from memory)."])
-     ]
-
-unpinState :: UnpinStateParams -> Argo.Method ServerState ()
-unpinState (UnpinStateParams stateID) = Argo.unpinState stateID
+destroyState :: DestroyStateParams -> Argo.Notification ()
+destroyState (DestroyStateParams stateID) = Argo.destroyState stateID
 
 
 
 ------------------------------------------------------------------------
--- Unpin All States Command
-data UnpinAllStatesParams = UnpinAllStatesParams
+-- Destroy All States Command
+data DestroyAllStatesParams = DestroyAllStatesParams
 
-instance JSON.FromJSON UnpinAllStatesParams where
+instance JSON.FromJSON DestroyAllStatesParams where
   parseJSON =
-    JSON.withObject "params for \"unpin all states\"" $
-    \_ -> pure UnpinAllStatesParams
+    JSON.withObject "params for \"destroy all states\"" $
+    \_ -> pure DestroyAllStatesParams
 
-instance Doc.DescribedParams UnpinAllStatesParams where
+instance Doc.DescribedParams DestroyAllStatesParams where
   parameterFieldDescription = []
 
 
-unpinAllStates :: UnpinAllStatesParams -> Argo.Method ServerState ()
-unpinAllStates _ = Argo.unpinAllStates
-
-------------------------------------------------------------------------
--- Set Cache Limit Command
-data SetCacheLimitParams =
-  SetCacheLimitParams
-  {
-    desiredCacheLimit :: !Int
-  }
-
-instance JSON.FromJSON SetCacheLimitParams where
-  parseJSON =
-    JSON.withObject "params for \"set cache limit\"" $
-    \o -> SetCacheLimitParams <$> o .: "cache limit"
-
-instance Doc.DescribedParams SetCacheLimitParams where
-  parameterFieldDescription = 
-    [("cache limit",
-      Doc.Paragraph [Doc.Text "Limit how many temporarily cached states can accumulate."])]
-
-setCacheLimit :: SetCacheLimitParams -> Argo.Method ServerState ()
-setCacheLimit (SetCacheLimitParams n) = Argo.setCacheLimit n
+destroyAllStates :: DestroyAllStatesParams -> Argo.Notification ()
+destroyAllStates _ = Argo.destroyAllStates
 

--- a/file-echo-api/src/FileEchoServer.hs
+++ b/file-echo-api/src/FileEchoServer.hs
@@ -167,7 +167,7 @@ instance Doc.DescribedParams ShowParams where
                               ]
 
 
-showCmd :: ShowParams -> Argo.Command ServerState JSON.Value
+showCmd :: ShowParams -> Argo.Query ServerState JSON.Value
 showCmd (ShowParams start end) =
   do (FileContents contents) <-  fileContents <$> Argo.getState
      let len = case end of
@@ -177,7 +177,7 @@ showCmd (ShowParams start end) =
 
 
 ------------------------------------------------------------------------
--- Implode Command
+-- Implode Query
 
 data ImplodeParams = ImplodeParams
 
@@ -190,7 +190,7 @@ instance Doc.DescribedParams ImplodeParams where
   parameterFieldDescription = []
 
 
-implodeCmd :: ClearParams -> Argo.Command ServerState ()
+implodeCmd :: ClearParams -> Argo.Query ServerState ()
 implodeCmd _ = liftIO $ throwIO Argo.internalError
 
 ----------------------------------------------------------------------
@@ -234,7 +234,7 @@ instance Doc.DescribedParams IgnoreParams where
     [("to be ignored",
       Doc.Paragraph [Doc.Text "The value to be ignored goes here."])]
 
-ignoreCmd :: IgnoreParams -> Argo.Command ServerState ()
+ignoreCmd :: IgnoreParams -> Argo.Query ServerState ()
 ignoreCmd _ = pure ()
 
 

--- a/file-echo-api/src/MutableFileEchoServer.hs
+++ b/file-echo-api/src/MutableFileEchoServer.hs
@@ -123,7 +123,7 @@ instance Doc.DescribedParams ShowParams where
                               ]
 
 
-showCmd :: ShowParams -> Argo.Command ServerState JSON.Value
+showCmd :: ShowParams -> Argo.Query ServerState JSON.Value
 showCmd (ShowParams start end) = do
   appState <- Argo.getState
   (FileContents contents) <- liftIO $ readIORef $ fileContents appState

--- a/file-echo-api/src/MutableFileEchoServer.hs
+++ b/file-echo-api/src/MutableFileEchoServer.hs
@@ -1,0 +1,154 @@
+{-# LANGUAGE OverloadedStrings #-}
+{- Like FileEchoServer but the underlying state uses mutability
+   to update the loaded file contents. -}
+module MutableFileEchoServer ( module MutableFileEchoServer ) where
+
+import qualified Argo as Argo
+import qualified Argo.Doc as Doc
+import Control.Exception ( throwIO )
+import Control.Monad.IO.Class ( liftIO )
+import qualified Data.Aeson as JSON
+import Data.Aeson ( (.:), (.:?), (.=), (.!=) )
+import Data.ByteString ( ByteString )
+import Data.IORef ( IORef, newIORef, readIORef, writeIORef)
+import qualified Data.ByteString.Char8 as Char8
+import qualified Data.Text as T
+import qualified System.Directory as Dir
+
+
+
+newtype FileContents = FileContents String
+
+data ServerState = ServerState
+  { loadedFile :: Maybe FilePath
+  -- ^ Loaded file (if any).
+  , fileContents :: IORef FileContents
+  -- ^ Current file contents, or "" if one has not been loaded yet.
+  }
+
+initialState ::
+  Maybe FilePath ->
+  (FilePath -> IO ByteString) ->
+  IO ServerState
+initialState Nothing _reader = do
+  contentRef <- newIORef (FileContents "")
+  pure $ ServerState Nothing contentRef
+initialState (Just path) reader = do 
+  contents <- FileContents . Char8.unpack <$> reader path
+  contentRef <- newIORef contents
+  pure $ ServerState (Just path) contentRef
+
+newtype ServerErr = ServerErr String
+newtype ServerRes a = ServerRes (Either ServerErr (a, FileContents))
+newtype ServerCmd a =
+  ServerCmd ((FilePath -> IO ByteString, FileContents) -> IO (ServerRes a))
+
+
+------------------------------------------------------------------------
+-- Command Execution
+
+runServerCmd :: ServerCmd a -> Argo.Method ServerState a
+runServerCmd (ServerCmd cmd) = do 
+  contentRef <-  fileContents <$> Argo.getState
+  contents <- liftIO $ readIORef contentRef
+  reader <- Argo.getFileReader
+  out <- liftIO $ cmd (reader, contents)
+  case out of
+    ServerRes (Left (ServerErr message)) ->
+      Argo.raise $ Argo.makeJSONRPCException
+       11000 "File Server exception"
+       (Just (JSON.object ["error" .= message]))
+    ServerRes (Right (x, newFileContents)) -> do
+      liftIO $ writeIORef contentRef newFileContents
+      return x
+
+
+------------------------------------------------------------------------
+-- Errors
+
+fileNotFound :: FilePath -> Argo.JSONRPCException
+fileNotFound fp =
+  Argo.makeJSONRPCException
+    20051 (T.pack ("File doesn't exist: " <> fp))
+    (Just (JSON.object ["path" .= fp]))
+
+------------------------------------------------------------------------
+-- Load Command
+
+data LoadParams = LoadParams FilePath
+
+instance JSON.FromJSON LoadParams where
+  parseJSON =
+    JSON.withObject "params for \"load\"" $
+    \o -> LoadParams <$> o .: "file path"
+
+instance Doc.DescribedParams LoadParams where
+  parameterFieldDescription =
+    [("file path",
+      Doc.Paragraph [Doc.Text "The file to read into memory."])]
+
+loadCmd :: LoadParams -> Argo.Method ServerState ()
+loadCmd (LoadParams file) =
+  do exists <- liftIO $ Dir.doesFileExist file
+     if exists
+     then do getFileContents <- Argo.getFileReader
+             contents <- liftIO $ getFileContents file
+             appState <- Argo.getState
+             liftIO $ writeIORef (fileContents appState) $ FileContents $ Char8.unpack contents
+             Argo.setState $ appState { loadedFile = Just file }
+     else Argo.raise (fileNotFound file)
+
+
+------------------------------------------------------------------------
+-- Clear Command
+
+data ClearParams = ClearParams
+
+instance JSON.FromJSON ClearParams where
+  parseJSON =
+    JSON.withObject "params for \"show\"" $
+    \_ -> pure ClearParams
+
+instance Doc.DescribedParams ClearParams where
+  parameterFieldDescription = []
+
+clearCmd :: ClearParams -> Argo.Method ServerState ()
+clearCmd _ = do
+  appState <- Argo.getState
+  liftIO $ writeIORef (fileContents appState) $ FileContents ""
+  Argo.setState $ appState { loadedFile = Nothing }
+
+------------------------------------------------------------------------
+-- Show Command
+
+data ShowParams = ShowParams
+  { showStart :: Int
+    -- ^ Inclusive start index in contents.
+  , showEnd :: Maybe Int
+  -- ^ Exclusive end index in contents.
+  }
+
+instance JSON.FromJSON ShowParams where
+  parseJSON =
+    JSON.withObject "params for \"show\"" $
+    \o -> do start <- o .:? "start" .!= 0
+             end <- o   .:? "end"
+             pure $ ShowParams start end
+
+instance Doc.DescribedParams ShowParams where
+  parameterFieldDescription =
+    [ ("start",
+       Doc.Paragraph [Doc.Text "Start index (inclusive). If not provided, the substring is from the beginning of the file."])
+    , ("end", Doc.Paragraph [Doc.Text "End index (exclusive). If not provided, the remainder of the file is returned."])
+                              ]
+
+
+showCmd :: ShowParams -> Argo.Method ServerState JSON.Value
+showCmd (ShowParams start end) = do
+  appState <- Argo.getState
+  (FileContents contents) <- liftIO $ readIORef $ fileContents appState
+  let len = case end of
+            Nothing -> length contents
+            Just idx -> idx - start
+  pure (JSON.object [ "value" .= JSON.String (T.pack $ take len $ drop start contents)])
+

--- a/python/setup.py
+++ b/python/setup.py
@@ -12,7 +12,7 @@ def get_README():
 setup(
     name="argo-client",
     python_requires=">=3.7",
-    version="0.0.3",
+    version="0.0.4",
     url="https://github.com/GaloisInc/argo",
     project_urls={
         "Changelog": "https://github.com/GaloisInc/argo/blob/master/python/CHANGELOG.md",

--- a/python/tests/test-data/base.txt
+++ b/python/tests/test-data/base.txt
@@ -1,0 +1,1 @@
+All your base are belong to us!

--- a/python/tests/test_file_echo_api.py
+++ b/python/tests/test_file_echo_api.py
@@ -314,7 +314,7 @@ class RemoteSocketProcessTests(GenericFileEchoTests, unittest.TestCase):
     @classmethod
     def setUpClass(self):
         p = subprocess.Popen(
-            ["cabal", "run", "file-echo-api", "--verbose=0", "--", "socket", "--port", "50005"],
+            ["cabal", "run", "exe:file-echo-api", "--verbose=0", "--", "socket", "--port", "50005"],
             stdout=subprocess.PIPE,
             stdin=subprocess.DEVNULL,
             stderr=subprocess.PIPE,
@@ -352,7 +352,7 @@ class DynamicSocketProcessTests(GenericFileEchoTests, unittest.TestCase):
     @classmethod
     def setUpClass(self):
         self.c = argo.ServerConnection(
-                    argo.DynamicSocketProcess("cabal run file-echo-api --verbose=0 -- socket --port 50006"))
+                    argo.DynamicSocketProcess("cabal run exe:file-echo-api --verbose=0 -- socket --port 50006"))
 
     # to be implemented by classes extending this one
     def get_connection(self):
@@ -368,7 +368,7 @@ class StdIOProcessTests(GenericFileEchoTests, unittest.TestCase):
     @classmethod
     def setUpClass(self):
         self.c = argo.ServerConnection(
-                    argo.StdIOProcess("cabal run file-echo-api --verbose=0 -- stdio"))
+                    argo.StdIOProcess("cabal run exe:file-echo-api --verbose=0 -- stdio"))
 
     def get_connection(self):
         return self.c
@@ -386,7 +386,7 @@ class HttpTests(GenericFileEchoTests, unittest.TestCase):
     @classmethod
     def setUpClass(self):
         p = subprocess.Popen(
-            ["cabal", "run", "file-echo-api", "--verbose=0", "--", "http", "/", "--port", "8080"],
+            ["cabal", "run", "exe:file-echo-api", "--verbose=0", "--", "http", "/", "--port", "8080"],
             stdout=subprocess.PIPE,
             stdin=subprocess.DEVNULL,
             stderr=subprocess.PIPE,
@@ -453,7 +453,7 @@ class LoadOnLaunchTests(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         p = subprocess.Popen(
-            ["cabal", "run", "file-echo-api", "--verbose=0", "--", "http", "/", "--port", "8081", "--file", str(hello_file)],
+            ["cabal", "run", "exe:file-echo-api", "--verbose=0", "--", "http", "/", "--port", "8081", "--file", str(hello_file)],
             stdout=subprocess.PIPE,
             stdin=subprocess.DEVNULL,
             stderr=subprocess.PIPE,

--- a/python/tests/test_file_echo_api.py
+++ b/python/tests/test_file_echo_api.py
@@ -6,6 +6,7 @@ import time
 import json
 import unittest
 import signal
+from typing import Optional, Tuple
 
 import argo_client.connection as argo
 
@@ -19,11 +20,6 @@ if not file_dir.is_dir():
 
 # Test the custom command line argument to load a file at server start
 hello_file = file_dir.joinpath('hello.txt')
-
-# What the response to "show" looks like
-def show_res(*,content,uid,state):
-    r = {'result':{'state':state,'stdout':'','stderr':'','answer':{'value':content}},'jsonrpc':'2.0','id':uid}
-    return r
 
 # What the response looks like when a state is not in cache/pinned on the server
 def bad_state_res(*,uid,state):
@@ -40,7 +36,6 @@ def gen_misc_states(c, iterations):
         uid = c.send_command("drop", {"count":3, "state": state})
         state = c.wait_for_reply_to(uid)['result']['state']
 
-
 class GenericFileEchoTests():
 
 
@@ -48,72 +43,92 @@ class GenericFileEchoTests():
     def get_connection(self): pass
     def get_caching_iterations(self): pass
 
+    def assertShow(
+        self : unittest.TestCase,
+        connection : argo.ServerConnection,
+        state : Optional[str],
+        expected : str,
+        *,
+        startEnd : Optional[Tuple[int,int]] = None) -> Tuple[int, str]:
+        """Send a `show` command from `state` and ensure it returns `expected`.
+        
+        Returns the request uid and state in a tuple."""
+
+        next_state = None
+        if startEnd is None:
+            uid = connection.send_query("show", {"state": state})
+        else:
+            (start, end) = startEnd
+            uid = connection.send_query("show", {"start":start, "end":end, "state": state})
+        actual = connection.wait_for_reply_to(uid)
+        self.assertIn('result', actual)
+        if 'result' in actual:
+            self.assertIn('state', actual['result'])
+            if 'state' in actual['result']:
+                next_state = actual['result']['state']
+            self.assertIn('answer', actual['result'])
+            if 'answer' in actual['result']:
+                self.assertIn('value', actual['result']['answer'])
+                if 'value' in actual['result']['answer']:
+                    self.assertEqual(actual['result']['answer']['value'], expected)
+        
+        return (uid, next_state)
+
     def test_basics(self):
         c = self.get_connection()
         ## Positive tests -- make sure the server behaves as we expect with valid RPCs
 
         # Check that their is nothing to show if we haven't loaded a file yet
-        uid = c.send_query("show", {"state": None})
-        actual = c.wait_for_reply_to(uid)
-        expected = show_res(content='',uid=uid,state=None)
-        self.assertEqual(actual, expected)
-        prev_uid = uid
+        (prev_uid, prev_state) = self.assertShow(c, state=None, expected='')
+
 
         # load a file
         hello_file = file_dir.joinpath('hello.txt')
         self.assertTrue(False if not hello_file.is_file() else True)
-        uid = c.send_command("load", {"file path": str(hello_file), "state": None})
+        uid = c.send_command("load", {"file path": str(hello_file), "state": prev_state})
         actual = c.wait_for_reply_to(uid)
         self.assertTrue('result' in actual and 'state' in actual['result'])
-        hello_state = actual['result']['state']
-        expected = {'result':{'state':hello_state,'stdout':'','stderr':'','answer':[]},'jsonrpc':'2.0','id':uid}
+        state = actual['result']['state']
+        expected = {'result':{'state':state,'stdout':'','stderr':'','answer':[]},'jsonrpc':'2.0','id':uid}
         self.assertEqual(actual, expected)
         self.assertNotEqual(uid, prev_uid)
-        self.assertNotEqual(hello_state, None)
+        self.assertNotEqual(state, prev_state)
         prev_uid = uid
+        prev_state = state
 
         # check the contents of the loaded file
-        uid = c.send_query("show", {"state": hello_state})
-        actual = c.wait_for_reply_to(uid)
-        expected = show_res(content='Hello World!\n',uid=uid,state=hello_state)
-        self.assertEqual(actual, expected)
-        self.assertNotEqual(uid, prev_uid)
-        prev_uid = uid
+        (prev_uid, prev_state) = self.assertShow(c, state=prev_state, expected='Hello World!\n')
 
         # check a _portion_ of the contents of the loaded file
-        uid = c.send_query("show", {"start":1, "end":5, "state": hello_state})
-        actual = c.wait_for_reply_to(uid)
-        self.assertEqual(actual, show_res(content='ello',uid=uid,state=hello_state))
-        self.assertNotEqual(uid, prev_uid)
-        prev_uid = uid
+        (prev_uid, prev_state) = self.assertShow(c, state=prev_state, expected='ello', startEnd=(1,5))
 
         # clear the loaded file
-        uid = c.send_command("clear", {"state": hello_state})
+        uid = c.send_command("clear", {"state": prev_state})
         actual = c.wait_for_reply_to(uid)
         self.assertTrue('result' in actual and 'state' in actual['result'])
-        cleared_state = actual['result']['state']
-        expected = {'result':{'state':cleared_state,'stdout':'','stderr':'','answer':[]},'jsonrpc':'2.0','id':uid}
+        state = actual['result']['state']
+        expected = {'result':{'state':state,'stdout':'','stderr':'','answer':[]},'jsonrpc':'2.0','id':uid}
         self.assertEqual(actual, expected)
-        self.assertNotEqual(cleared_state, hello_state)
+        self.assertNotEqual(state, prev_state)
         self.assertNotEqual(uid, prev_uid)
+        prev_uid = uid
+        prev_state = state
 
         # check that the file contents cleared
-        uid = c.send_query("show", {"state": cleared_state})
-        actual = c.wait_for_reply_to(uid)
-        self.assertEqual(actual, show_res(content='',uid=uid,state=cleared_state))
+        (prev_uid, prev_state) = self.assertShow(c, state=prev_state, expected='')
 
         ## Negative tests -- make sure the server errors as we expect
 
         # Method not found
-        uid = c.send_command("bad function", {"state": cleared_state})
+        uid = c.send_command("bad function", {"state": prev_state})
         actual = c.wait_for_reply_to(uid)
         expected = {'error':{'data':{'stdout':None,'data':'bad function','stderr':None},'code':-32601,'message':'Method not found'},'jsonrpc':'2.0','id':uid}
         self.assertEqual(actual, expected)
 
         # Invalid params
-        uid = c.send_command("load", {"file path": 12345, "state": cleared_state})
+        uid = c.send_command("load", {"file path": 12345, "state": prev_state})
         actual = c.wait_for_reply_to(uid)
-        expected = {'error':{'data':{'stdout':'','data':{'state':cleared_state,'file path':12345},'stderr':''},'code':-32602,'message':'Invalid params: expected String, but encountered Number'},'jsonrpc':'2.0','id':uid}
+        expected = {'error':{'data':{'stdout':'','data':{'state':prev_state,'file path':12345},'stderr':''},'code':-32602,'message':'Invalid params: expected String, but encountered Number'},'jsonrpc':'2.0','id':uid}
         self.assertEqual(actual, expected)
 
         # load a nonexistent file, check error that is returned
@@ -121,14 +136,14 @@ class GenericFileEchoTests():
         if nonexistent_file.is_file():
             print('ERROR: ' + str(nonexistent_file) + ' was expected to not exist, but it does!')
             assert(False)
-        uid = c.send_command("load", {"file path": str(nonexistent_file), "state": cleared_state})
+        uid = c.send_command("load", {"file path": str(nonexistent_file), "state": prev_state})
         actual = c.wait_for_reply_to(uid)
         expected = {'error':{'data':{'stdout':'','data':{'path':str(nonexistent_file)},'stderr':''},'code':20051,'message':'File doesn\'t exist: ' + str(nonexistent_file)},'jsonrpc':'2.0','id':uid}
         self.assertEqual(actual, expected)
 
 
         # cause server to have an internal error
-        uid = c.send_command("implode", {"state": cleared_state})
+        uid = c.send_command("implode", {"state": prev_state})
         actual = c.wait_for_reply_to(uid)
         expected = {'error':{'data':{'stdout':'','stderr':''},'code':-32603,'message':'Internal error'},'jsonrpc':'2.0','id':uid}
         self.assertEqual(actual, expected)
@@ -153,156 +168,6 @@ class GenericFileEchoTests():
         actual = c.wait_for_reply_to(None)
         expected = {'error':{'data':{'stdout':None,'data':'Error in $: Failed reading: not a valid json value at \'BAAAAADJSON\'','stderr':None},'code':-32700,'message':'Parse error'},'jsonrpc':'2.0','id':None}
         self.assertEqual(actual, expected)
-
-    def test_caching(self):
-        c = self.get_connection()
-        iterations = self.get_caching_iterations()
-
-        # set cache max size to 10 to start
-        c.send_notification("set cache limit", {"state": None, "cache limit": 10})
-
-        # Check that their is nothing to show if we haven't loaded a file yet
-        uid = c.send_query("show", {"state": None})
-        actual = c.wait_for_reply_to(uid)
-        expected = show_res(content='',uid=uid,state=None)
-        self.assertEqual(actual, expected)
-
-        # Make a misc state to pin and pin it
-        uid = c.send_command("prepend", {"content":"I am in a pinned state", "state": None})
-        actual = c.wait_for_reply_to(uid)
-        pinned_state = actual['result']['state']
-        uid = c.send_query("show", {"state": pinned_state})
-        actual = c.wait_for_reply_to(uid)
-        expected = show_res(content="I am in a pinned state",uid=uid,state=pinned_state)
-        self.assertEqual(actual, expected)
-
-        # pin the state
-        c.send_notification("pin state", {"state": pinned_state, "state to pin": pinned_state})
-
-        # Check that the pinned state is reachable
-        uid = c.send_query("show", {"state": pinned_state})
-        actual = c.wait_for_reply_to(uid)
-        expected = show_res(content="I am in a pinned state",uid=uid,state=pinned_state)
-        self.assertEqual(actual, expected)
-
-        seen_states = [None]
-        expected = ''
-
-        # Basically append 10 'c's onto the empty string in a funny way, and then clear the string, over and over
-        # (i.e., make a lot of new states, not all of which should fit in the ephemeral cache)
-        for i in range(1,iterations):
-            # append "abc" on the left
-            uid = c.send_command("prepend", {"content":"abc", "state": seen_states[len(seen_states) - 1]})
-            seen_states.append(c.wait_for_reply_to(uid)['result']['state'])
-            if i % 10 == 0:
-                # clear the string by dropping the "ab" and 10 accumulated "c"s from the front
-                expected = ""
-                uid = c.send_command("drop", {"count":12, "state": seen_states[len(seen_states) - 1]})
-                seen_states.append(c.wait_for_reply_to(uid)['result']['state'])
-                uid = c.send_query("show", {"state": seen_states[len(seen_states) - 1]})
-                actual = c.wait_for_reply_to(uid)['result']['answer']['value']
-                self.assertEqual(expected, actual)
-            else:
-                uid = c.send_command("drop", {"count":2, "state": seen_states[len(seen_states) - 1]})
-                seen_states.append(c.wait_for_reply_to(uid)['result']['state'])
-                uid = c.send_query("show", {"state": seen_states[len(seen_states) - 1]})
-                actual = c.wait_for_reply_to(uid)['result']['answer']['value']
-                # we dropped the "ab", but the "c" remains
-                expected += 'c'
-                self.assertEqual(expected, actual)
-            uid = c.send_query("show", {"state": seen_states[1]})
-            actual = c.wait_for_reply_to(uid)['result']['answer']['value']
-            self.assertEqual('abc', actual)
-
-
-        # Check that the initial state is still reachable
-        uid = c.send_query("show", {"state": None})
-        actual = c.wait_for_reply_to(uid)
-        self.assertEqual(actual, show_res(content="",uid=uid,state=None))
-
-
-        # Check that the last couple states and the one we kept revisiting are still live/reachable
-        uid = c.send_query("show", {"state": seen_states[len(seen_states) - 1]})
-        actual = c.wait_for_reply_to(uid)['result']['answer']['value']
-        self.assertEqual(expected, actual)
-        uid = c.send_query("show", {"state": seen_states[len(seen_states) - 2]})
-        actual = c.wait_for_reply_to(uid)['result']['answer']['value']
-        self.assertEqual('ab' + expected, actual)
-        uid = c.send_query("show", {"state": seen_states[len(seen_states) - 3]})
-        actual = c.wait_for_reply_to(uid)['result']['answer']['value']
-        self.assertEqual(expected[:len(expected) - 1], actual)
-        uid = c.send_query("show", {"state": seen_states[1]})
-        actual = c.wait_for_reply_to(uid)['result']['answer']['value']
-        self.assertEqual('abc', actual)
-
-        # Check that old stale states are no longer reachable in the cache
-        for i in range(2,50):
-            uid = c.send_query("show", {"state": seen_states[i]})
-            actual = c.wait_for_reply_to(uid)
-            expected = bad_state_res(uid=uid,state=seen_states[i])
-            self.assertEqual(actual, expected)
-
-        # Check that the pinned state is still reachable
-        uid = c.send_query("show", {"state": pinned_state})
-        actual = c.wait_for_reply_to(uid)
-        expected = show_res(content="I am in a pinned state",uid=uid,state=pinned_state)
-        self.assertEqual(actual, expected)
-
-        # unpinn the pinned state
-        c.send_notification("unpin state", {"state": pinned_state, "state to unpin":pinned_state})
-        # create some misc traffic so the now unpinned state goes away
-        gen_misc_states(c, 100)
-
-        # send a request with a now invalid state id
-        uid = c.send_query("show", {"state": pinned_state})
-        actual = c.wait_for_reply_to(uid)
-        expected = bad_state_res(uid=uid,state=pinned_state)
-        self.assertEqual(actual, expected)
-
-        # make a new pinned state
-        uid = c.send_command("prepend", {"content":"I am another pinned state", "state": None})
-        pinned_state = c.wait_for_reply_to(uid)['result']['state']
-        c.send_notification("pin state", {"state": pinned_state, "state to pin": pinned_state})
-        # misc traffic
-        gen_misc_states(c, 100)
-        # check that it's still pinned
-        uid = c.send_query("show", {"state": pinned_state})
-        actual = c.wait_for_reply_to(uid)
-        self.assertEqual(actual['result']['answer']['value'], "I am another pinned state")
-
-        # unpinn the pinned state by unpinning all pinned states
-        c.send_notification("unpin all states", {"state": pinned_state})
-        # create some misc traffic so the now unpinned state goes away
-        gen_misc_states(c, 100)
-
-        # send a request with a now invalid state id
-        uid = c.send_query("show", {"state": pinned_state})
-        actual = c.wait_for_reply_to(uid)
-        expected = bad_state_res(uid=uid,state=pinned_state)
-        self.assertEqual(actual, expected)
-
-        # reduce the cache max size to 0
-        c.send_notification("set cache limit", {"state": None, "cache limit": 0})
-        
-        # Now make sure we can linearly use the states, but anything older than the previous is gone.
-        for i in range(1, 20):
-            # append "foo" on the left then remove it, over and over to churn through states
-            uid = c.send_command("prepend", {"content":"foo", "state": None})
-            state1 = c.wait_for_reply_to(uid)['result']['state']
-            uid = c.send_query("show", {"state": state1})
-            actual = c.wait_for_reply_to(uid)
-            self.assertEqual(actual, show_res(content="foo",uid=uid,state=state1))
-            uid = c.send_command("drop", {"count":3, "state": state1})
-            state2 = c.wait_for_reply_to(uid)['result']['state']
-            uid = c.send_query("show", {"state": state2})
-            actual = c.wait_for_reply_to(uid)
-            self.assertEqual(actual, show_res(content="",uid=uid,state=state2))
-            # check that the first state is missing as we expect
-            uid = c.send_query("show", {"state": state1})
-            actual = c.wait_for_reply_to(uid)
-            self.assertEqual(actual, bad_state_res(uid=uid,state=state1))
-
-
 
 
 class RemoteSocketProcessTests(GenericFileEchoTests, unittest.TestCase):
@@ -480,5 +345,113 @@ class LoadOnLaunchTests(unittest.TestCase):
     def test_load_on_launch(self):
         uid = self.c.send_query("show", {"state": None})
         actual = self.c.wait_for_reply_to(uid)
-        expected = {'result':{'state':None,'stdout':'','stderr':'','answer':{'value':'Hello World!\n'}},'jsonrpc':'2.0','id':uid}
+        self.assertIn('result', actual)
+        self.assertIn('state', actual['result'])
+        expected = {'result':{'state':actual['result']['state'],'stdout':'','stderr':'','answer':{'value':'Hello World!\n'}},'jsonrpc':'2.0','id':uid}
         self.assertEqual(actual, expected)
+
+
+class OccupancyTests(unittest.TestCase):
+    # Connection to server
+    c = None
+    # process running the server
+    p = None
+
+    @classmethod
+    def setUpClass(self):
+        p = subprocess.Popen(
+            ["cabal", "run", "exe:file-echo-api", "--verbose=0", "--", "--max-occupancy", "2", "http", "/", "--port", "8082", "--file", str(hello_file)],
+            stdout=subprocess.PIPE,
+            stdin=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            start_new_session=True)
+        time.sleep(3)
+        assert(p is not None)
+        poll_result = p.poll()
+        if poll_result is not None:
+            print(poll_result)
+            print(p.stdout.read())
+            print(p.stderr.read())
+        assert(poll_result is None)
+
+        self.p = p
+
+    @classmethod
+    def tearDownClass(self):
+        os.killpg(os.getpgid(self.p.pid), signal.SIGKILL)
+        super().tearDownClass()
+
+    # to be implemented by classes extending this one
+    def test_occupancy_and_state_destruction(self):
+        c1 = argo.ServerConnection(argo.HttpProcess('http://localhost:8082/'))
+        c2 = argo.ServerConnection(argo.HttpProcess('http://localhost:8082/'))
+        # load a file
+        hello_file = file_dir.joinpath('hello.txt')
+        self.assertTrue(False if not hello_file.is_file() else True)
+        uid1 = c1.send_command("load", {"file path": str(hello_file), "state": None})
+        uid2 = c2.send_command("load", {"file path": str(hello_file), "state": None})
+        actual1 = c1.wait_for_reply_to(uid1)
+        self.assertIn('result', actual1)
+        self.assertIn('state', actual1['result'])
+        state1 = actual1['result']['state']
+        actual2 = c2.wait_for_reply_to(uid2)
+        self.assertIn('result', actual2)
+        self.assertIn('state', actual2['result'])
+        state2 = actual2['result']['state']
+
+        # check the next (3rd) connection is rejected
+        c3 = argo.ServerConnection(argo.HttpProcess('http://localhost:8082/'))
+        uid3 = c3.send_command("load", {"file path": str(hello_file), "state": None})
+        actual3 = c3.wait_for_reply_to(uid3)
+        expected = {'error':{'data':{'stdout':None,'stderr':None},'code':22,'message':'Server at max capacity'},'jsonrpc':'2.0','id':uid3}
+        self.assertEqual(actual3, expected)
+
+        # kill connection 1's state
+        c1.send_notification("destroy state", {"state to destroy": state1})
+        # ensure connection 1's state is dead
+        uid1 = c1.send_command("show", {"state": state1})
+        actual1 = c1.wait_for_reply_to(uid1)
+        expected = {'error':{'data':{'stdout':None,'data':state1,'stderr':None},'code':20,'message':'Unknown state ID'},'jsonrpc':'2.0','id':uid1}
+        self.assertEqual(actual1, expected)
+
+        # now connection 3 should succeed
+        uid3 = c3.send_command("load", {"file path": str(hello_file), "state": None})
+        actual3 = c3.wait_for_reply_to(uid3)
+        self.assertIn('result', actual3)
+        self.assertIn('state', actual3['result'])
+        state3 = actual3['result']['state']
+
+        # kill all the connection's state
+        c1.send_notification("destroy all states", {})
+
+        # ensure connection 2's state is dead
+        uid2 = c2.send_command("show", {"state": state2})
+        actual2 = c2.wait_for_reply_to(uid2)
+        expected = {'error':{'data':{'stdout':None,'data':state2,'stderr':None},'code':20,'message':'Unknown state ID'},'jsonrpc':'2.0','id':uid2}
+        self.assertEqual(actual2, expected)
+
+        # ensure connection 3's state is dead
+        uid3 = c3.send_command("show", {"state": state3})
+        actual3 = c3.wait_for_reply_to(uid3)
+        expected = {'error':{'data':{'stdout':None,'data':state3,'stderr':None},'code':20,'message':'Unknown state ID'},'jsonrpc':'2.0','id':uid3}
+        self.assertEqual(actual3, expected)
+
+        # now ensure there's room for two more new connections
+        uid1 = c1.send_command("load", {"file path": str(hello_file), "state": None})
+        uid2 = c2.send_command("load", {"file path": str(hello_file), "state": None})
+        actual1 = c1.wait_for_reply_to(uid1)
+        self.assertIn('result', actual1)
+        self.assertIn('state', actual1['result'])
+        state1 = actual1['result']['state']
+        actual2 = c2.wait_for_reply_to(uid2)
+        self.assertIn('result', actual2)
+        self.assertIn('state', actual2['result'])
+        state2 = actual2['result']['state']
+
+        # check again that the next (3rd) connection is rejected
+        c3 = argo.ServerConnection(argo.HttpProcess('http://localhost:8082/'))
+        uid3 = c3.send_command("load", {"file path": str(hello_file), "state": None})
+        actual3 = c3.wait_for_reply_to(uid3)
+        expected = {'error':{'data':{'stdout':None,'stderr':None},'code':22,'message':'Server at max capacity'},'jsonrpc':'2.0','id':uid3}
+        self.assertEqual(actual3, expected)
+

--- a/python/tests/test_file_echo_interaction.py
+++ b/python/tests/test_file_echo_interaction.py
@@ -1,0 +1,207 @@
+import os
+import unittest
+import argo_client.interaction as argo
+from pathlib import Path
+from argo_client.interaction import HasProtocolState, ArgoException
+from argo_client.connection import ServerConnection, StdIOProcess
+from typing import Any, Optional
+
+class LoadFile(argo.Command):
+    def __init__(self, connection : HasProtocolState, file_path : str) -> None:
+        super(LoadFile, self).__init__('load', {'file path': file_path}, connection)
+
+    def process_result(self, res : Any) -> Any:
+        return res
+
+class Implode(argo.Command):
+    def __init__(self, connection : HasProtocolState) -> None:
+        super(Implode, self).__init__('implode', {}, connection)
+
+    def process_result(self, res : Any) -> Any:
+        return res
+
+class Show(argo.Query):
+    def __init__(self, connection : HasProtocolState, start : Optional[int], end : Optional[int]) -> None:
+        params = {'state': connection.protocol_state()}
+        if start is not None:
+            params['start'] += start
+        if end is not None:
+            params['end'] += end
+        super(Show, self).__init__('show', params, connection)
+
+    def process_result(self, res : Any) -> Any:
+        return res['value']
+
+class Reset(argo.Notification):
+    def __init__(self, connection : HasProtocolState) -> None:
+        super(Reset, self).__init__('destroy state', {'state to destroy': connection.protocol_state()}, connection)
+
+
+class FileEchoConnection:
+    most_recent_result : Optional[argo.Interaction]
+    server_connection : ServerConnection
+
+    def __init__(self, connection : ServerConnection):
+        self.most_recent_result = None
+        self.server_connection = connection
+
+    def protocol_state(self) -> Any:
+        if self.most_recent_result is None:
+            return None
+        else:
+            return self.most_recent_result.state()
+
+    
+    def load_file(self, filename : str) -> argo.Command:
+        """Load a file's contents into the server.
+        """
+        self.most_recent_result = LoadFile(self, filename)
+        return self.most_recent_result
+
+    def implode(self) -> argo.Command:
+        """Cause an internal server error.
+        """
+        self.most_recent_result = Implode(self)
+        return self.most_recent_result
+
+    def show(self, *, start : int = None, end : int = None) -> argo.Query:
+        """Load a file's contents into the server.
+        """
+        self.most_recent_result = Show(self, start = start, end = end)
+        return self.most_recent_result
+
+    def reset(self) -> None:
+        """Reset the underlying server state."""
+        Reset(self)
+        self.most_recent_result = None
+
+dir_path = Path(os.path.dirname(os.path.realpath(__file__)))
+file_dir = dir_path.joinpath('test-data')
+if not file_dir.is_dir():
+    print('ERROR: ' + str(file_dir) + ' is not a directory!')
+    assert(False)
+
+class BasicInteractionTests(unittest.TestCase):
+    # Connection to server
+    c : FileEchoConnection = None
+
+    @classmethod
+    def setUpClass(self):
+        self.c = FileEchoConnection(
+                    argo.ServerConnection(
+                        StdIOProcess(
+                            "cabal run exe:file-echo-api --verbose=0 -- stdio")))
+
+    def test_basics(self):
+        c = self.c
+        hello_file = file_dir.joinpath('hello.txt')
+        self.assertTrue(False if not hello_file.is_file() else True)
+
+        # test loading and showing a valid file
+        c.load_file(str(hello_file))
+        self.assertEqual(c.show().result(), "Hello World!\n")
+
+        c.reset()
+
+
+class CommandErrorInteractionTests1(unittest.TestCase):
+    # Connection to server
+    c : FileEchoConnection = None
+
+    @classmethod
+    def setUpClass(self):
+        self.c = FileEchoConnection(
+                    argo.ServerConnection(
+                        StdIOProcess(
+                            "cabal run exe:file-echo-api --verbose=0 -- stdio")))
+
+    def test_missing_file(self):
+        c = self.c
+
+        # test loading a non-existant file
+        halo_file = file_dir.joinpath('halo.txt') # <- file doesn't exist
+        self.assertFalse(False if not halo_file.is_file() else True)
+        with self.assertRaises(ArgoException):
+            c.load_file(str(halo_file)).result()
+
+        # test that internal errors without extra data raise proper exceptions
+        with self.assertRaises(ArgoException):
+            c.implode().result()
+
+
+class CommandErrorInteractionTests2(unittest.TestCase):
+    # Connection to server
+    c : FileEchoConnection = None
+
+    @classmethod
+    def setUpClass(self):
+        self.c = FileEchoConnection(
+                    argo.ServerConnection(
+                        StdIOProcess(
+                            "cabal run exe:file-echo-api --verbose=0 -- stdio")))
+
+    def test_implosion_after_load(self):
+        c = self.c
+
+        hello_file = file_dir.joinpath('hello.txt')
+        self.assertTrue(False if not hello_file.is_file() else True)
+
+        # test loading and showing a valid file
+        c.load_file(str(hello_file))
+        self.assertEqual(c.show().result(), "Hello World!\n")
+
+        # test that internal errors without extra data raise proper exceptions
+        with self.assertRaises(ArgoException):
+            c.implode().result()
+
+
+class CommandErrorInteractionTests3(unittest.TestCase):
+    # Connection to server
+    c : FileEchoConnection = None
+
+    @classmethod
+    def setUpClass(self):
+        self.c = FileEchoConnection(
+                    argo.ServerConnection(
+                        StdIOProcess(
+                            "cabal run exe:file-echo-api --verbose=0 -- stdio")))
+
+    def test_only_implision(self):
+        c = self.c
+
+        # test that internal errors without extra data raise proper exceptions
+        with self.assertRaises(ArgoException):
+            c.implode().result()
+
+
+class CommandErrorInteractionTests4(unittest.TestCase):
+    # Connection to server
+    c : FileEchoConnection = None
+
+    @classmethod
+    def setUpClass(self):
+        self.c = FileEchoConnection(
+                    argo.ServerConnection(
+                        StdIOProcess(
+                            "cabal run exe:file-echo-api --verbose=0 -- stdio")))
+
+    def test_load_after_reset(self):
+        c = self.c
+
+        hello_file = file_dir.joinpath('hello.txt')
+        self.assertTrue(False if not hello_file.is_file() else True)
+
+        # test loading and showing a valid file
+        c.load_file(str(hello_file))
+        self.assertEqual(c.show().result(), "Hello World!\n")
+
+        c.reset()
+
+        # post reset connection is in initial state
+        self.assertEqual(c.show().result(), "")
+
+        # test loading and showing a valid file after a reset
+        base_file = file_dir.joinpath('base.txt')
+        self.assertTrue(False if not base_file.is_file() else True)
+        c.load_file(str(base_file))
+        self.assertEqual(c.show().result(), "All your base are belong to us!\n")

--- a/python/tests/test_mutable_file_echo_api.py
+++ b/python/tests/test_mutable_file_echo_api.py
@@ -1,0 +1,140 @@
+import os
+from pathlib import Path
+import subprocess
+import time
+import unittest
+import signal
+
+import argo_client.connection as argo
+
+dir_path = Path(os.path.dirname(os.path.realpath(__file__)))
+
+file_dir = dir_path.joinpath('test-data')
+
+if not file_dir.is_dir():
+    print('ERROR: ' + str(file_dir) + ' is not a directory!')
+    assert(False)
+
+# Test the custom command line argument to load a file at server start
+hello_file = file_dir.joinpath('hello.txt')
+
+# What the response to "show" looks like
+def show_res(*,content,uid,state):
+    r = {'result':{'state':state,'stdout':'','stderr':'','answer':{'value':content}},'jsonrpc':'2.0','id':uid}
+    return r
+
+# What the response looks like when a state is not in cache/pinned on the server
+def bad_state_res(*,uid,state):
+    r = {'error':{'data':{'stdout':None,'data':state,'stderr':None},'code':20,'message':'Unknown state ID'},'jsonrpc':'2.0','id':uid}
+    return r
+
+# Helper to churn through states on the server
+def gen_misc_states(c, iterations):
+    state = None
+    for i in range (1,iterations):
+        # append "foo" on the left then remove it, over and over to churn through states
+        uid = c.send_command("prepend", {"content":"foo", "state": state})
+        state = c.wait_for_reply_to(uid)['result']['state']
+        uid = c.send_command("drop", {"count":3, "state": state})
+        state = c.wait_for_reply_to(uid)['result']['state']
+
+
+class MutableFileEchoTests(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+        p = subprocess.Popen(
+            ["cabal", "run", "exe:mutable-file-echo-api", "--verbose=0", "--", "http", "/", "--port", "8080"],
+            stdout=subprocess.PIPE,
+            stdin=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            start_new_session=True)
+        time.sleep(3)
+        assert(p is not None)
+        poll_result = p.poll()
+        if poll_result is not None:
+            print(poll_result)
+            print(p.stdout.read())
+            print(p.stderr.read())
+        assert(poll_result is None)
+
+        self.p = p
+        self.other_c = argo.ServerConnection(argo.HttpProcess('http://localhost:8080/'))
+
+
+    @classmethod
+    def tearDownClass(self):
+        os.killpg(os.getpgid(self.p.pid), signal.SIGKILL)
+        super().tearDownClass()
+
+    def test_subsequent_connection(self):
+        c = argo.ServerConnection(argo.HttpProcess('http://localhost:8080/'))
+        ## Positive tests -- make sure the server behaves as we expect with valid RPCs
+
+        # [c] Check that their is nothing to show if we haven't loaded a file yet
+        uid = c.send_query("show", {"state": None})
+        actual = c.wait_for_reply_to(uid)
+        expected = show_res(content='',uid=uid,state=None)
+        self.assertEqual(actual, expected)
+        prev_uid = uid
+
+        # [c] load a file
+        hello_file = file_dir.joinpath('hello.txt')
+        self.assertTrue(False if not hello_file.is_file() else True)
+        uid = c.send_command("load", {"file path": str(hello_file), "state": None})
+        actual = c.wait_for_reply_to(uid)
+        self.assertTrue('result' in actual and 'state' in actual['result'])
+        hello_state = actual['result']['state']
+        expected = {'result':{'state':hello_state,'stdout':'','stderr':'','answer':[]},'jsonrpc':'2.0','id':uid}
+        self.assertEqual(actual, expected)
+        self.assertNotEqual(uid, prev_uid)
+        self.assertNotEqual(hello_state, None)
+        prev_uid = uid
+
+        # [c] check the contents of the loaded file
+        uid = c.send_query("show", {"state": hello_state})
+        actual = c.wait_for_reply_to(uid)
+        expected = show_res(content='Hello World!\n',uid=uid,state=hello_state)
+        self.assertEqual(actual, expected)
+        self.assertNotEqual(uid, prev_uid)
+        prev_uid = uid
+
+        # [other_c] start a subsequent connection
+        other_c = argo.ServerConnection(argo.HttpProcess('http://localhost:8080/'))
+
+        # [other_c] check that the other connection has nothing to show if we haven't loaded our own file yet
+        other_uid = other_c.send_query("show", {"state": None})
+        actual = other_c.wait_for_reply_to(other_uid)
+        expected = show_res(content='',uid=other_uid,state=None)
+        self.assertEqual(actual, expected)
+        other_prev_uid = other_uid
+
+        # [other_c] load a file
+        base_file = file_dir.joinpath('base.txt')
+        other_uid = other_c.send_command("load", {"file path": str(base_file), "state": None})
+        actual = other_c.wait_for_reply_to(other_uid)
+        self.assertTrue('result' in actual and 'state' in actual['result'])
+        base_state = actual['result']['state']
+        expected = {'result':{'state':base_state,'stdout':'','stderr':'','answer':[]},'jsonrpc':'2.0','id':other_uid}
+        self.assertEqual(actual, expected)
+        self.assertNotEqual(other_uid, other_prev_uid)
+        self.assertNotEqual(base_state, None)
+        other_prev_uid = other_uid
+
+        # [other_c] clear the loaded file
+        other_uid = other_c.send_command("clear", {"state": base_state})
+        actual = c.wait_for_reply_to(uid)
+        self.assertTrue('result' in actual and 'state' in actual['result'])
+        cleared_state = actual['result']['state']
+        expected = {'result':{'state':cleared_state,'stdout':'','stderr':'','answer':[]},'jsonrpc':'2.0','id':other_uid}
+        self.assertEqual(actual, expected)
+        self.assertNotEqual(cleared_state, base_state)
+        self.assertNotEqual(other_uid, other_prev_uid)
+
+        # [c] check the contents of the loaded file again in the original connection
+        uid = c.send_query("show", {"state": hello_state})
+        actual = c.wait_for_reply_to(uid)
+        expected = show_res(content='Hello World!\n',uid=uid,state=hello_state)
+        self.assertEqual(actual, expected)
+        self.assertNotEqual(uid, prev_uid)
+        prev_uid = uid

--- a/python/tests/test_mutable_file_echo_api.py
+++ b/python/tests/test_mutable_file_echo_api.py
@@ -4,6 +4,7 @@ import subprocess
 import time
 import unittest
 import signal
+from typing import Optional, Tuple
 
 import argo_client.connection as argo
 
@@ -18,25 +19,11 @@ if not file_dir.is_dir():
 # Test the custom command line argument to load a file at server start
 hello_file = file_dir.joinpath('hello.txt')
 
-# What the response to "show" looks like
-def show_res(*,content,uid,state):
-    r = {'result':{'state':state,'stdout':'','stderr':'','answer':{'value':content}},'jsonrpc':'2.0','id':uid}
-    return r
 
 # What the response looks like when a state is not in cache/pinned on the server
 def bad_state_res(*,uid,state):
     r = {'error':{'data':{'stdout':None,'data':state,'stderr':None},'code':20,'message':'Unknown state ID'},'jsonrpc':'2.0','id':uid}
     return r
-
-# Helper to churn through states on the server
-def gen_misc_states(c, iterations):
-    state = None
-    for i in range (1,iterations):
-        # append "foo" on the left then remove it, over and over to churn through states
-        uid = c.send_command("prepend", {"content":"foo", "state": state})
-        state = c.wait_for_reply_to(uid)['result']['state']
-        uid = c.send_command("drop", {"count":3, "state": state})
-        state = c.wait_for_reply_to(uid)['result']['state']
 
 
 class MutableFileEchoTests(unittest.TestCase):
@@ -67,74 +54,80 @@ class MutableFileEchoTests(unittest.TestCase):
         os.killpg(os.getpgid(self.p.pid), signal.SIGKILL)
         super().tearDownClass()
 
+    def assertShow(self, connection : argo.ServerConnection, state : Optional[str], expected : str) -> Tuple[int, str]:
+        """Send a `show` command from `state` and ensure it returns `expected`.
+        
+        Returns the request uid and state in a tuple."""
+
+        next_state = None
+        uid = connection.send_query("show", {"state": state})
+        actual = connection.wait_for_reply_to(uid)
+        self.assertIn('result', actual)
+        if 'result' in actual:
+            self.assertIn('state', actual['result'])
+            if 'state' in actual['result']:
+                next_state = actual['result']['state']
+            self.assertIn('answer', actual['result'])
+            if 'answer' in actual['result']:
+                self.assertIn('value', actual['result']['answer'])
+                if 'value' in actual['result']['answer']:
+                    self.assertEqual(actual['result']['answer']['value'], expected)
+        
+        return (uid, next_state)
+
+
     def test_subsequent_connection(self):
         c = argo.ServerConnection(argo.HttpProcess('http://localhost:8080/'))
         ## Positive tests -- make sure the server behaves as we expect with valid RPCs
 
         # [c] Check that their is nothing to show if we haven't loaded a file yet
-        uid = c.send_query("show", {"state": None})
-        actual = c.wait_for_reply_to(uid)
-        expected = show_res(content='',uid=uid,state=None)
-        self.assertEqual(actual, expected)
-        prev_uid = uid
+        (prev_uid, state) = self.assertShow(c, state=None,expected='')
 
         # [c] load a file
         hello_file = file_dir.joinpath('hello.txt')
         self.assertTrue(False if not hello_file.is_file() else True)
-        uid = c.send_command("load", {"file path": str(hello_file), "state": None})
+        uid = c.send_command("load", {"file path": str(hello_file), "state": state})
         actual = c.wait_for_reply_to(uid)
         self.assertTrue('result' in actual and 'state' in actual['result'])
-        hello_state = actual['result']['state']
-        expected = {'result':{'state':hello_state,'stdout':'','stderr':'','answer':[]},'jsonrpc':'2.0','id':uid}
+        state = actual['result']['state']
+        expected = {'result':{'state':state,'stdout':'','stderr':'','answer':[]},'jsonrpc':'2.0','id':uid}
         self.assertEqual(actual, expected)
         self.assertNotEqual(uid, prev_uid)
-        self.assertNotEqual(hello_state, None)
+        self.assertNotEqual(state, None)
         prev_uid = uid
 
         # [c] check the contents of the loaded file
-        uid = c.send_query("show", {"state": hello_state})
-        actual = c.wait_for_reply_to(uid)
-        expected = show_res(content='Hello World!\n',uid=uid,state=hello_state)
-        self.assertEqual(actual, expected)
-        self.assertNotEqual(uid, prev_uid)
-        prev_uid = uid
+        (prev_uid, state) = self.assertShow(c, state=state,expected='Hello World!\n')
 
         # [other_c] start a subsequent connection
         other_c = argo.ServerConnection(argo.HttpProcess('http://localhost:8080/'))
 
         # [other_c] check that the other connection has nothing to show if we haven't loaded our own file yet
-        other_uid = other_c.send_query("show", {"state": None})
-        actual = other_c.wait_for_reply_to(other_uid)
-        expected = show_res(content='',uid=other_uid,state=None)
-        self.assertEqual(actual, expected)
-        other_prev_uid = other_uid
+        (other_prev_uid, other_state) = self.assertShow(other_c, state=None,expected='')
+
 
         # [other_c] load a file
         base_file = file_dir.joinpath('base.txt')
-        other_uid = other_c.send_command("load", {"file path": str(base_file), "state": None})
+        other_uid = other_c.send_command("load", {"file path": str(base_file), "state": other_state})
         actual = other_c.wait_for_reply_to(other_uid)
         self.assertTrue('result' in actual and 'state' in actual['result'])
-        base_state = actual['result']['state']
-        expected = {'result':{'state':base_state,'stdout':'','stderr':'','answer':[]},'jsonrpc':'2.0','id':other_uid}
+        other_state = actual['result']['state']
+        expected = {'result':{'state':other_state,'stdout':'','stderr':'','answer':[]},'jsonrpc':'2.0','id':other_uid}
         self.assertEqual(actual, expected)
         self.assertNotEqual(other_uid, other_prev_uid)
-        self.assertNotEqual(base_state, None)
+        self.assertNotEqual(other_state, None)
         other_prev_uid = other_uid
 
         # [other_c] clear the loaded file
-        other_uid = other_c.send_command("clear", {"state": base_state})
-        actual = c.wait_for_reply_to(uid)
+        other_uid = other_c.send_command("clear", {"state": other_state})
+        actual = other_c.wait_for_reply_to(other_uid)
         self.assertTrue('result' in actual and 'state' in actual['result'])
         cleared_state = actual['result']['state']
         expected = {'result':{'state':cleared_state,'stdout':'','stderr':'','answer':[]},'jsonrpc':'2.0','id':other_uid}
         self.assertEqual(actual, expected)
-        self.assertNotEqual(cleared_state, base_state)
+        self.assertNotEqual(cleared_state, other_state)
         self.assertNotEqual(other_uid, other_prev_uid)
 
         # [c] check the contents of the loaded file again in the original connection
-        uid = c.send_query("show", {"state": hello_state})
-        actual = c.wait_for_reply_to(uid)
-        expected = show_res(content='Hello World!\n',uid=uid,state=hello_state)
-        self.assertEqual(actual, expected)
-        self.assertNotEqual(uid, prev_uid)
-        prev_uid = uid
+        (prev_uid, state) = self.assertShow(c, state=state,expected='Hello World!\n')
+


### PR DESCRIPTION
This PR adds support for servers with mutable state (like SAW's). This is accomplished as follows:

1. mkApp (i.e., the creation of an Argo server app) takes a `StateMutability` in the `AppOpts`, which indicates if initial states must be re-created for every new use (`MutableState`) or whether the same one can be reused for each new initial request (`PureState`).

2. `StateID` usage (for non-initial states) is now destructive, which will make preventing mutation in the underlying server from affecting other requests trivial. I.e., a when a command is made from a particular (non-initial) `StateID`, that `StateID` is destroyed and is no longer reachable, and a new `StateID` is associated with the resulting state from that request (regardless of whether or not the state actually changed). Down the road we can get more nuanced with this and keep states alive if they are in fact still valid and there is a desire to do so, but for now I think it keeps the implementation simple and safe and it meets all of the use cases we have encountered so far in practice.

3. The `Command`/`Query` distinction is gone -- for now all operations are `Command`s. Commands can touch state, and (as mentioned above) always destroy the `StateID` they are initiated from.

4. `Notification`s cannot touch individual states (i.e., they do not have corresponding `StateID`s), and are primarily used for server management (e.g., like when a connection is done performing calculations, a notification can "free" it's last `StateID`).

5. A `--max-occupancy` flag allows a server at launch to specify how many simultaneously live states may exist on the server at once (excluding the initial state). This, combined with proper "freeing" of states which are no longer needed (see (4)), should allow the server to not be overwhelmed beyond the specified max, while still allowing ongoing connections/operations as states are freed after use. Right now the state free-ing is manual (there is a way to free _all_ states as an escape hatch) -- later perhaps we want to make this smarter, add timeouts, etc, but I think this should suffice for now.

