### PR TITLE
RFC: Support autogenerated documentation for method results, in addition to parameters

### DIFF
--- a/argo/src/Argo/Doc.hs
+++ b/argo/src/Argo/Doc.hs
@@ -1,8 +1,11 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
-module Argo.Doc (LinkTarget(..), Block(..), Inline(..), Described(..), DescribedParams(..), datatype) where
+module Argo.Doc (LinkTarget(..), Block(..), Inline(..), Described(..), DescribedMethod(..), datatype) where
 
 import Data.List.NonEmpty
 import Data.Text (Text)
@@ -35,13 +38,36 @@ class Described a where
   description :: [Block]
 
 
--- | This class provides the canonical documentation for a datatype
--- that is deserialized as parameters to some method via a @FromJSON@
--- instance. The type variable does not occur in the method's
--- signature because it is intended to be used with the
--- @TypeApplications@ extension to GHC Haskell.
-class DescribedParams a where
+-- | This class provides the canonical documentation for a pair of datatypes,
+-- where:
+--
+-- * The first datatype (@params@) is deserialized as parameters to some method
+--   via a @FromJSON@ instance, and
+--
+-- * The second datatype (@result@) is serialized as the result returned by the
+--   same method via a @ToJSON@ instance.
+--
+-- The @params@ type is almost always a custom data type defined for the
+-- purpose of interfacing with RPC, which is why @result@ has a functional
+-- dependency on @params@. On the other hand, it is common for @result@ to be
+-- off-the-shelf data types such as @Value@ (for methods that return a JSON
+-- object) or @()@ (for methods that do not return any values).
+--
+-- Neither @params@ nor @result@ occur in the signatures of the methods
+-- because they are intended to be used with the @TypeApplications@ extension
+-- to GHC Haskell.
+class DescribedMethod params result | params -> result where
+  -- | Documentation for the parameters expected by the method.
   parameterFieldDescription :: [(Text, Block)]
+
+  -- | Documentation for the result returned by the method.
+  --
+  -- If the method does not return anything—that is, if @result@ is
+  -- @()@—then this method does not need to be implemented, as it will be
+  -- defaulted appropriately.
+  resultFieldDescription :: [(Text, Block)]
+  default resultFieldDescription :: (result ~ ()) => [(Text, Block)]
+  resultFieldDescription = []
 
 datatype :: forall a . (Typeable a, Described a) => Block
 datatype =

--- a/file-echo-api/README.rst
+++ b/file-echo-api/README.rst
@@ -93,54 +93,109 @@ Methods
 load (command)
 ~~~~~~~~~~~~~~
 
+Load a file from disk into memory.
+
+Parameter fields
+++++++++++++++++
+
 
 ``file path``
   The file to read into memory.
   
   
-Load a file from disk into memory.
+
+Return fields
++++++++++++++
+
+No return fields
+
 
 
 clear (command)
 ~~~~~~~~~~~~~~~
 
+Forget the loaded file.
+
+Parameter fields
+++++++++++++++++
+
 No parameters
 
-Forget the loaded file.
+
+Return fields
++++++++++++++
+
+No return fields
+
 
 
 prepend (command)
 ~~~~~~~~~~~~~~~~~
+
+Append a string to the left of the current contents.
+
+Parameter fields
+++++++++++++++++
 
 
 ``content``
   The string to append to the left of the current file content on the server.
   
   
-Append a string to the left of the current contents.
+
+Return fields
++++++++++++++
+
+No return fields
+
 
 
 drop (command)
 ~~~~~~~~~~~~~~
+
+Drop from the left of the current contents.
+
+Parameter fields
+++++++++++++++++
 
 
 ``count``
   The number of characters to drop from the left of the current file content on the server.
   
   
-Drop from the left of the current contents.
+
+Return fields
++++++++++++++
+
+No return fields
+
 
 
 implode (query)
 ~~~~~~~~~~~~~~~
 
+Throw an error immediately.
+
+Parameter fields
+++++++++++++++++
+
 No parameters
 
-Throw an error immediately.
+
+Return fields
++++++++++++++
+
+No return fields
+
 
 
 show (query)
 ~~~~~~~~~~~~
+
+Show a substring of the file.
+
+Parameter fields
+++++++++++++++++
 
 
 ``start``
@@ -152,37 +207,75 @@ show (query)
   End index (exclusive). If not provided, the remainder of the file is returned.
   
   
-Show a substring of the file.
+
+Return fields
++++++++++++++
+
+
+``value``
+  The substring ranging from ``start`` to ``end``.
+  
+  
 
 
 ignore (query)
 ~~~~~~~~~~~~~~
+
+Ignore an :ref:`ignorable value <Ignorable>`.
+
+Parameter fields
+++++++++++++++++
 
 
 ``to be ignored``
   The value to be ignored goes here.
   
   
-Ignore an :ref:`ignorable value <Ignorable>`.
+
+Return fields
++++++++++++++
+
+No return fields
+
 
 
 destroy state (notification)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Destroy a state in the server.
+
+Parameter fields
+++++++++++++++++
 
 
 ``state to destroy``
   The state to destroy in the server (so it can be released from memory).
   
   
-Destroy a state in the server.
+
+Return fields
++++++++++++++
+
+No return fields
+
 
 
 destroy all states (notification)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Destroy all states in the server.
+
+Parameter fields
+++++++++++++++++
+
 No parameters
 
-Destroy all states in the server.
+
+Return fields
++++++++++++++
+
+No return fields
+
 
 
 

--- a/file-echo-api/src/FileEchoServer.hs
+++ b/file-echo-api/src/FileEchoServer.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 module FileEchoServer ( module FileEchoServer ) where
 
@@ -58,7 +59,7 @@ instance JSON.FromJSON LoadParams where
     JSON.withObject "params for \"load\"" $
     \o -> LoadParams <$> o .: "file path"
 
-instance Doc.DescribedParams LoadParams where
+instance Doc.DescribedMethod LoadParams () where
   parameterFieldDescription =
     [("file path",
       Doc.Paragraph [Doc.Text "The file to read into memory."])]
@@ -86,7 +87,7 @@ instance JSON.FromJSON PrependParams where
     JSON.withObject "params for \"prepend\"" $
     \o -> PrependParams <$> o .: "content"
 
-instance Doc.DescribedParams PrependParams where
+instance Doc.DescribedMethod PrependParams () where
   parameterFieldDescription =
     [("content",
       Doc.Paragraph [Doc.Text "The string to append to the left of the current file content on the server."])]
@@ -109,7 +110,7 @@ instance JSON.FromJSON DropParams where
     JSON.withObject "params for \"drop\"" $
     \o -> DropParams <$> o .: "count"
 
-instance Doc.DescribedParams DropParams where
+instance Doc.DescribedMethod DropParams () where
   parameterFieldDescription =
     [("count",
       Doc.Paragraph [Doc.Text "The number of characters to drop from the left of the current file content on the server."])]
@@ -132,7 +133,7 @@ instance JSON.FromJSON ClearParams where
     JSON.withObject "params for \"show\"" $
     \_ -> pure ClearParams
 
-instance Doc.DescribedParams ClearParams where
+instance Doc.DescribedMethod ClearParams () where
   parameterFieldDescription = []
 
 clearCmd :: ClearParams -> Argo.Command ServerState ()
@@ -159,12 +160,19 @@ instance JSON.FromJSON ShowParams where
              end <- o   .:? "end"
              pure $ ShowParams start end
 
-instance Doc.DescribedParams ShowParams where
+instance Doc.DescribedMethod ShowParams JSON.Value where
   parameterFieldDescription =
     [ ("start",
        Doc.Paragraph [Doc.Text "Start index (inclusive). If not provided, the substring is from the beginning of the file."])
     , ("end", Doc.Paragraph [Doc.Text "End index (exclusive). If not provided, the remainder of the file is returned."])
                               ]
+
+  resultFieldDescription =
+    [ ("value",
+      Doc.Paragraph [ Doc.Text "The substring ranging from "
+                    , Doc.Literal "start", Doc.Text " to ", Doc.Literal "end"
+                    , Doc.Text "." ])
+    ]
 
 
 showCmd :: ShowParams -> Argo.Query ServerState JSON.Value
@@ -186,7 +194,7 @@ instance JSON.FromJSON ImplodeParams where
     JSON.withObject "params for \"implode\"" $
     \_ -> pure ImplodeParams
 
-instance Doc.DescribedParams ImplodeParams where
+instance Doc.DescribedMethod ImplodeParams () where
   parameterFieldDescription = []
 
 
@@ -229,7 +237,7 @@ instance JSON.FromJSON IgnoreParams where
     JSON.withObject "params for \"ignore\"" $
       \o -> IgnoreParams <$> o .: "to be ignored"
 
-instance Doc.DescribedParams IgnoreParams where
+instance Doc.DescribedMethod IgnoreParams () where
   parameterFieldDescription =
     [("to be ignored",
       Doc.Paragraph [Doc.Text "The value to be ignored goes here."])]
@@ -251,8 +259,8 @@ instance JSON.FromJSON DestroyStateParams where
     JSON.withObject "params for \"destroy state\"" $
     \o -> DestroyStateParams <$> o .: "state to destroy"
 
-instance Doc.DescribedParams DestroyStateParams where
-  parameterFieldDescription = 
+instance Doc.DescribedMethod DestroyStateParams () where
+  parameterFieldDescription =
     [("state to destroy",
        Doc.Paragraph [Doc.Text "The state to destroy in the server (so it can be released from memory)."])
      ]
@@ -271,7 +279,7 @@ instance JSON.FromJSON DestroyAllStatesParams where
     JSON.withObject "params for \"destroy all states\"" $
     \_ -> pure DestroyAllStatesParams
 
-instance Doc.DescribedParams DestroyAllStatesParams where
+instance Doc.DescribedMethod DestroyAllStatesParams () where
   parameterFieldDescription = []
 
 


### PR DESCRIPTION
Currently, the `DescribedParams` class allows for declaring the documentation for the _parameters_ of methods, but not the _results_. This makes it insufficient for generating the sorts of documentation like what is written [here](https://github.com/GaloisInc/saw-script/blob/7bb93c9b5c08422a49017e49772d8d2db3ff8fb0/saw-remote-api/docs/old-Saw.rst#running-proof-scripts) in the handwritten SAW remote API docs.

This is an attempt at augmenting the `DescribedParams` class to allow documenting result values in addition to parameters. Some of the highlights are:

* The class has now been renamed to `DescribedMethod` to reflect its more general purpose.
* `DescribedMethod` now has two type parameters: `params` (which existed before) and `result`. There is a `params -> result` functional dependency since the `params` type is almost always a custom data type, whereas `result` can often be off-the-shelf data types like `Value` and `()`.
* In addition to the `parameterFieldDescription` method, there is now a `resultFieldDescription` method. It has a default implementation of `[]` in the common case where `result` is `()` (i.e., nothing is returned).
* There has been some reorganization of the autogenerated documentation so that there is a more clear separation of the parameters and results.