### PR TITLE
CI: Use haskell/actions/setup to install GHC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
       with:
         submodules: true
     - name: Get GHC
-      run: |
-        sudo apt-get install --no-install-recommends -y cabal-install-3.2 ghc-${{ matrix.ghc-ver }}
-        echo "/opt/cabal/bin" >> $GITHUB_PATH
-        echo "/opt/ghc/${{ matrix.ghc-ver }}/bin" >> $GITHUB_PATH
+      uses: haskell/actions/setup@v1
+      id: setup-haskell
+      with:
+        ghc-version: ${{ matrix.ghc-ver }}
     - name: Cache
       uses: actions/cache@v1
       with:


### PR DESCRIPTION
The workflow was previously relying on an Ubuntu GHC PPA being pre-added on each GitHub Actions runner, but this no longer happens after actions/virtual-environments#3268. Better to just use `haskell/actions/setup` to install GHC instead, which does the hard work of figuring out how to install GHC for us.