### PR TITLE
Bump upper version bounds on base to allow building with GHC 9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc-ver: ["8.6.5", "8.8.4", "8.10.2"]
+        ghc-ver: ["8.6.5", "8.8.4", "8.10.2", "9.0.1"]
       # complete all jobs
       fail-fast: false
     name: Argo - GHC v${{ matrix.ghc-ver }} - ubuntu-latest

--- a/argo/argo.cabal
+++ b/argo/argo.cabal
@@ -31,7 +31,7 @@ common warnings
 
 common deps
   build-depends:
-    base                         >= 4.11.1.0 && < 4.15,
+    base                         >= 4.11.1.0 && < 4.16,
     aeson                        >= 1.4.2,
     async                       ^>= 2.2,
     bytestring                  ^>= 0.10.8,

--- a/file-echo-api/file-echo-api.cabal
+++ b/file-echo-api/file-echo-api.cabal
@@ -25,7 +25,7 @@ common warnings
 
 common deps
   build-depends:
-    base                 >=4.11.1.0 && <4.15,
+    base                 >=4.11.1.0 && <4.16,
     argo,
     aeson                >= 1.4.2,
     bytestring           ^>= 0.10.8,


### PR DESCRIPTION
Also add a GHC 9.0.1 configuration in CI.