### PR TITLE
feat: server can now be interrupted, cancelling all active requests

### DIFF
--- a/argo/src/Argo/ServerState.hs
+++ b/argo/src/Argo/ServerState.hs
@@ -128,7 +128,7 @@ nextAppState server prevStateID newAppState = do
   modifyIORef' (serverStatePool server) $ HM.insert uuid newAppState
   return $ StateID uuid
 
--- | Desctroy an app state so it is no longer available for requests.
+-- | Destroy an app state so it is no longer available for requests.
 destroyAppState' ::
   ServerState s ->
   StateID ->

--- a/argo/src/Argo/ServerState.hs
+++ b/argo/src/Argo/ServerState.hs
@@ -136,7 +136,7 @@ destroyAppState' ::
 destroyAppState' _server InitialStateID = pure ()
 destroyAppState' server (StateID uuid) = modifyIORef' (serverStatePool server) $ HM.delete uuid
 
--- | Desctroy an app state so it is no longer available for requests.
+-- | Destroy an app state so it is no longer available for requests.
 destroyAppState ::
   MVar (ServerState s) ->
   StateID ->

--- a/file-echo-api/file-echo-api.cabal
+++ b/file-echo-api/file-echo-api.cabal
@@ -34,6 +34,7 @@ common deps
     optparse-applicative >= 0.14 && < 0.17,
     scientific           ^>= 0.3,
     text                 ^>= 1.2.3,
+    time,
     unordered-containers ^>= 0.2,
     vector               ^>= 0.12,
 

--- a/file-echo-api/file-echo-api/Main.hs
+++ b/file-echo-api/file-echo-api/Main.hs
@@ -58,9 +58,12 @@ serverMethods =
   , Argo.command "clear" (Doc.Paragraph [Doc.Text "Forget the loaded file."]) FES.clearCmd
   , Argo.command "prepend" (Doc.Paragraph [Doc.Text "Append a string to the left of the current contents."]) FES.prependCmd
   , Argo.command "drop" (Doc.Paragraph [Doc.Text "Drop from the left of the current contents."]) FES.dropCmd
+  , Argo.command "slow clear" (Doc.Paragraph [Doc.Text "Forgets the loaded file slowly (i.e., char by char)."]) FES.slowClear
   , Argo.query "implode" (Doc.Paragraph [Doc.Text "Throw an error immediately."]) FES.implodeCmd
   , Argo.query "show" (Doc.Paragraph [Doc.Text "Show a substring of the file."]) FES.showCmd
   , Argo.query "ignore" (Doc.Paragraph [Doc.Text "Ignore an ", Doc.Link (Doc.TypeDesc (typeRep (Proxy @FES.Ignorable))) "ignorable value", Doc.Text "."]) FES.ignoreCmd
+  , Argo.query "sleep" (Doc.Paragraph [Doc.Text "Sleep for a specified number of microseconds."]) FES.sleepQuery
   , Argo.notification "destroy state" (Doc.Paragraph [Doc.Text "Destroy a state in the server."]) FES.destroyState
   , Argo.notification "destroy all states" (Doc.Paragraph [Doc.Text "Destroy all states in the server."]) FES.destroyAllStates
+  , Argo.notification "interrupt" (Doc.Paragraph [Doc.Text "Interrupt all threads in the server."]) FES.interruptAllThreads
   ]

--- a/file-echo-api/mutable-file-echo-api/Main.hs
+++ b/file-echo-api/mutable-file-echo-api/Main.hs
@@ -54,6 +54,9 @@ serverMethods :: [Argo.AppMethod MFES.ServerState]
 serverMethods =
   [ Argo.command "load" (Doc.Paragraph [Doc.Text "Load a file from disk into memory."]) MFES.loadCmd
   , Argo.command "clear" (Doc.Paragraph [Doc.Text "Forget the loaded file."]) MFES.clearCmd
+  , Argo.command "slow clear" (Doc.Paragraph [Doc.Text "Forgets the loaded file slowly (i.e., char by char)."]) MFES.slowClear
   , Argo.query "show" (Doc.Paragraph [Doc.Text "Show a substring of the file."]) MFES.showCmd
+  , Argo.query "sleep" (Doc.Paragraph [Doc.Text "Sleep for a specified number of microseconds."]) MFES.sleepQuery
   , Argo.notification "destroy state" (Doc.Paragraph [Doc.Text "Destroy a state."]) MFES.destroyState
+  , Argo.notification "interrupt" (Doc.Paragraph [Doc.Text "Interrupt all threads in the server."]) MFES.interruptAllThreads
   ]

--- a/file-echo-api/src/FileEchoServer.hs
+++ b/file-echo-api/src/FileEchoServer.hs
@@ -293,7 +293,7 @@ destroyAllStates _ = Argo.destroyAllStates
 ------------------------------------------------------------------------
 -- Sleep Query
 
-data SleepParams = SleepParams Int
+newtype SleepParams = SleepParams Int
 
 instance JSON.FromJSON SleepParams where
   parseJSON =

--- a/file-echo-api/src/FileEchoServer.hs
+++ b/file-echo-api/src/FileEchoServer.hs
@@ -4,6 +4,7 @@ module FileEchoServer ( module FileEchoServer ) where
 
 import qualified Argo as Argo
 import qualified Argo.Doc as Doc
+import Control.Concurrent ( threadDelay )
 import Control.Exception ( throwIO )
 import Control.Monad.IO.Class ( liftIO )
 import qualified Data.Aeson as JSON
@@ -11,6 +12,8 @@ import Data.Aeson ( (.:), (.:?), (.=), (.!=) )
 import Data.ByteString ( ByteString )
 import qualified Data.ByteString.Char8 as Char8
 import qualified Data.Text as T
+import Data.Time.Clock.POSIX
+import Data.Scientific (scientific)
 import qualified System.Directory as Dir
 
 
@@ -286,3 +289,75 @@ instance Doc.DescribedMethod DestroyAllStatesParams () where
 destroyAllStates :: DestroyAllStatesParams -> Argo.Notification ()
 destroyAllStates _ = Argo.destroyAllStates
 
+
+------------------------------------------------------------------------
+-- Sleep Query
+
+data SleepParams = SleepParams Int
+
+instance JSON.FromJSON SleepParams where
+  parseJSON =
+    JSON.withObject "params for \"sleep\"" $
+    \o -> SleepParams <$> o .: "microseconds"
+
+instance Doc.DescribedMethod SleepParams JSON.Value where
+  parameterFieldDescription =
+    [("microseconds",
+      Doc.Paragraph [Doc.Text "The duration to sleep in microseconds."])]
+
+  resultFieldDescription =
+    [ ("value",
+      Doc.Paragraph [ Doc.Text "Duration in seconds sleep lasted."])
+    ]
+
+sleepQuery :: SleepParams -> Argo.Query ServerState JSON.Value
+sleepQuery (SleepParams ms) = liftIO $ do
+  t1 <- round `fmap` getPOSIXTime
+  threadDelay ms
+  t2 <- round `fmap` getPOSIXTime
+  pure (JSON.object [ "value" .= (JSON.Number (scientific (t2 - t1) 0))])
+
+
+
+------------------------------------------------------------------------
+-- Interrupt All Threads Command
+data InterruptAllThreadsParams = InterruptAllThreadsParams
+
+instance JSON.FromJSON InterruptAllThreadsParams where
+  parseJSON =
+    JSON.withObject "params for \"interrupt all threads\"" $
+    \_ -> pure InterruptAllThreadsParams
+
+instance Doc.DescribedMethod InterruptAllThreadsParams () where
+  parameterFieldDescription = []
+
+
+interruptAllThreads :: InterruptAllThreadsParams -> Argo.Notification ()
+interruptAllThreads _ = Argo.interruptAllThreads
+
+
+------------------------------------------------------------------------
+-- SlowClear Command
+
+data SlowClear = SlowClear Int
+
+instance JSON.FromJSON SlowClear where
+  parseJSON =
+    JSON.withObject "params for \"slow clear\"" $
+    \o -> SlowClear <$> o .: "pause microseconds"
+
+instance Doc.DescribedMethod SlowClear () where
+  parameterFieldDescription =
+    [("pause microseconds",
+      Doc.Paragraph [Doc.Text "The duration to sleep in microseconds between each character being cleared."])]
+
+slowClear :: SlowClear -> Argo.Command ServerState ()
+slowClear (SlowClear ms) = do
+  let go = do (FileContents contents) <- fileContents <$> Argo.getState
+              case contents of
+                [] -> Argo.modifyState $ \s -> s { loadedFile = Nothing }
+                (_:cs) -> do
+                  Argo.modifyState $ \s -> s { fileContents = FileContents cs }
+                  liftIO $ threadDelay ms
+                  go
+  go

--- a/file-echo-api/src/FileEchoServer.hs
+++ b/file-echo-api/src/FileEchoServer.hs
@@ -339,7 +339,7 @@ interruptAllThreads _ = Argo.interruptAllThreads
 ------------------------------------------------------------------------
 -- SlowClear Command
 
-data SlowClear = SlowClear Int
+newtype SlowClear = SlowClear Int
 
 instance JSON.FromJSON SlowClear where
   parseJSON =

--- a/file-echo-api/src/MutableFileEchoServer.hs
+++ b/file-echo-api/src/MutableFileEchoServer.hs
@@ -169,7 +169,7 @@ destroyState (DestroyStateParams stateID) = Argo.destroyState stateID
 ------------------------------------------------------------------------
 -- Sleep Query
 
-data SleepParams = SleepParams Int
+newtype SleepParams = SleepParams Int
 
 instance JSON.FromJSON SleepParams where
   parseJSON =

--- a/file-echo-api/src/MutableFileEchoServer.hs
+++ b/file-echo-api/src/MutableFileEchoServer.hs
@@ -215,7 +215,7 @@ interruptAllThreads _ = Argo.interruptAllThreads
 ------------------------------------------------------------------------
 -- SlowClear Command
 
-data SlowClear = SlowClear Int
+newtype SlowClear = SlowClear Int
 
 instance JSON.FromJSON SlowClear where
   parseJSON =
@@ -238,4 +238,3 @@ slowClear (SlowClear ms) = do
                   liftIO $ threadDelay ms
                   go
   go
-

--- a/file-echo-api/src/MutableFileEchoServer.hs
+++ b/file-echo-api/src/MutableFileEchoServer.hs
@@ -6,6 +6,7 @@ module MutableFileEchoServer ( module MutableFileEchoServer ) where
 
 import qualified Argo as Argo
 import qualified Argo.Doc as Doc
+import Control.Concurrent ( threadDelay )
 import Control.Monad.IO.Class ( liftIO )
 import qualified Data.Aeson as JSON
 import Data.Aeson ( (.:), (.:?), (.=), (.!=) )
@@ -13,6 +14,8 @@ import Data.ByteString ( ByteString )
 import Data.IORef ( IORef, newIORef, readIORef, writeIORef)
 import qualified Data.ByteString.Char8 as Char8
 import qualified Data.Text as T
+import Data.Time.Clock.POSIX
+import Data.Scientific
 import qualified System.Directory as Dir
 
 
@@ -161,3 +164,78 @@ instance Doc.DescribedMethod DestroyStateParams () where
 
 destroyState :: DestroyStateParams -> Argo.Notification ()
 destroyState (DestroyStateParams stateID) = Argo.destroyState stateID
+
+
+------------------------------------------------------------------------
+-- Sleep Query
+
+data SleepParams = SleepParams Int
+
+instance JSON.FromJSON SleepParams where
+  parseJSON =
+    JSON.withObject "params for \"sleep\"" $
+    \o -> SleepParams <$> o .: "microseconds"
+
+instance Doc.DescribedMethod SleepParams JSON.Value where
+  parameterFieldDescription =
+    [("microseconds",
+      Doc.Paragraph [Doc.Text "The duration to sleep in microseconds."])]
+
+  resultFieldDescription =
+    [ ("value",
+      Doc.Paragraph [ Doc.Text "Duration in seconds sleep lasted."])
+    ]
+
+sleepQuery :: SleepParams -> Argo.Query ServerState JSON.Value
+sleepQuery (SleepParams ms) = liftIO $ do
+  t1 <- round `fmap` getPOSIXTime
+  threadDelay ms
+  t2 <- round `fmap` getPOSIXTime
+  pure (JSON.object [ "value" .= (JSON.Number (scientific (t2 - t1) 0))])
+
+
+
+------------------------------------------------------------------------
+-- Interrupt All Threads Command
+data InterruptAllThreadsParams = InterruptAllThreadsParams
+
+instance JSON.FromJSON InterruptAllThreadsParams where
+  parseJSON =
+    JSON.withObject "params for \"interrupt all threads\"" $
+    \_ -> pure InterruptAllThreadsParams
+
+instance Doc.DescribedMethod InterruptAllThreadsParams () where
+  parameterFieldDescription = []
+
+
+interruptAllThreads :: InterruptAllThreadsParams -> Argo.Notification ()
+interruptAllThreads _ = Argo.interruptAllThreads
+
+
+------------------------------------------------------------------------
+-- SlowClear Command
+
+data SlowClear = SlowClear Int
+
+instance JSON.FromJSON SlowClear where
+  parseJSON =
+    JSON.withObject "params for \"slow clear\"" $
+    \o -> SlowClear <$> o .: "pause microseconds"
+
+instance Doc.DescribedMethod SlowClear () where
+  parameterFieldDescription =
+    [("pause microseconds",
+      Doc.Paragraph [Doc.Text "The duration to sleep in microseconds between each character being cleared."])]
+
+slowClear :: SlowClear -> Argo.Command ServerState ()
+slowClear (SlowClear ms) = do
+  appState <- Argo.getState
+  let go = do (FileContents contents) <- liftIO $ readIORef (fileContents appState)
+              case contents of
+                [] -> Argo.modifyState $ \s -> s { loadedFile = Nothing }
+                (_:cs) -> do
+                  liftIO $ writeIORef (fileContents appState) $ FileContents cs
+                  liftIO $ threadDelay ms
+                  go
+  go
+

--- a/python/tests/test_file_echo_api.py
+++ b/python/tests/test_file_echo_api.py
@@ -36,6 +36,35 @@ def gen_misc_states(c, iterations):
         uid = c.send_command("drop", {"count":3, "state": state})
         state = c.wait_for_reply_to(uid)['result']['state']
 
+def assertShow(
+    self : unittest.TestCase,
+    connection : argo.ServerConnection,
+    state : Optional[str],
+    expected : str,
+    *,
+    startEnd : Optional[Tuple[int,int]] = None) -> int:
+    """Send a `show` command from `state` and ensure it returns `expected`.
+
+    Returns the request uid and state in a tuple."""
+
+    next_state = None
+    if startEnd is None:
+        uid = connection.send_query("show", {"state": state})
+    else:
+        (start, end) = startEnd
+        uid = connection.send_query("show", {"start":start, "end":end, "state": state})
+    actual = connection.wait_for_reply_to(uid)
+    self.assertIn('result', actual)
+    if 'result' in actual:
+        self.assertIn('state', actual['result'])
+        self.assertIn('answer', actual['result'])
+        if 'answer' in actual['result']:
+            self.assertIn('value', actual['result']['answer'])
+            if 'value' in actual['result']['answer']:
+                self.assertEqual(actual['result']['answer']['value'], expected)
+
+    return uid
+
 class GenericFileEchoTests():
 
 
@@ -43,41 +72,13 @@ class GenericFileEchoTests():
     def get_connection(self): pass
     def get_caching_iterations(self): pass
 
-    def assertShow(
-        self : unittest.TestCase,
-        connection : argo.ServerConnection,
-        state : Optional[str],
-        expected : str,
-        *,
-        startEnd : Optional[Tuple[int,int]] = None) -> int:
-        """Send a `show` command from `state` and ensure it returns `expected`.
-        
-        Returns the request uid and state in a tuple."""
-
-        next_state = None
-        if startEnd is None:
-            uid = connection.send_query("show", {"state": state})
-        else:
-            (start, end) = startEnd
-            uid = connection.send_query("show", {"start":start, "end":end, "state": state})
-        actual = connection.wait_for_reply_to(uid)
-        self.assertIn('result', actual)
-        if 'result' in actual:
-            self.assertIn('state', actual['result'])
-            self.assertIn('answer', actual['result'])
-            if 'answer' in actual['result']:
-                self.assertIn('value', actual['result']['answer'])
-                if 'value' in actual['result']['answer']:
-                    self.assertEqual(actual['result']['answer']['value'], expected)
-        
-        return uid
 
     def test_basics(self):
         c = self.get_connection()
         ## Positive tests -- make sure the server behaves as we expect with valid RPCs
 
         # Check that their is nothing to show if we haven't loaded a file yet
-        prev_uid = self.assertShow(c, state=None, expected='')
+        prev_uid = assertShow(self, c, state=None, expected='')
         prev_state = None
 
         # load a file
@@ -95,10 +96,10 @@ class GenericFileEchoTests():
         prev_state = state
 
         # check the contents of the loaded file
-        prev_uid = self.assertShow(c, state=prev_state, expected='Hello World!\n')
+        prev_uid = assertShow(self, c, state=prev_state, expected='Hello World!\n')
 
         # check a _portion_ of the contents of the loaded file
-        prev_uid = self.assertShow(c, state=prev_state, expected='ello', startEnd=(1,5))
+        prev_uid = assertShow(self, c, state=prev_state, expected='ello', startEnd=(1,5))
 
         # clear the loaded file
         uid = c.send_command("clear", {"state": prev_state})
@@ -113,7 +114,7 @@ class GenericFileEchoTests():
         prev_state = state
 
         # check that the file contents cleared
-        prev_uid = self.assertShow(c, state=prev_state, expected='')
+        prev_uid = assertShow(self, c, state=prev_state, expected='')
 
         ## Negative tests -- make sure the server errors as we expect
 
@@ -537,3 +538,102 @@ class OccupancyTests(unittest.TestCase):
         expected = {'error':{'data':{'stdout':None,'stderr':None},'code':22,'message':'Server at max capacity'},'jsonrpc':'2.0','id':uid3}
         self.assertEqual(actual3, expected)
 
+
+
+
+class InterruptTests(unittest.TestCase):
+    # Connection to server
+    c = None
+    # process running the server
+    p = None
+
+    @classmethod
+    def setUpClass(self):
+        p = subprocess.Popen(
+            ["cabal", "run", "exe:file-echo-api", "--verbose=0", "--", "--max-occupancy", "2", "http", "/", "--port", "8083", "--file", str(hello_file)],
+            stdout=subprocess.PIPE,
+            stdin=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            start_new_session=True)
+        time.sleep(3)
+        assert(p is not None)
+        poll_result = p.poll()
+        if poll_result is not None:
+            print(poll_result)
+            print(p.stdout.read())
+            print(p.stderr.read())
+        assert(poll_result is None)
+
+        self.p = p
+
+    @classmethod
+    def tearDownClass(self):
+        os.killpg(os.getpgid(self.p.pid), signal.SIGKILL)
+        super().tearDownClass()
+
+    # to be implemented by classes extending this one
+    def test_interrupts(self):
+        c1 = argo.ServerConnection(argo.HttpProcess('http://localhost:8083/'))
+        c2 = argo.ServerConnection(argo.HttpProcess('http://localhost:8083/'))
+        # load a file
+        hello_file = file_dir.joinpath('hello.txt')
+        self.assertTrue(False if not hello_file.is_file() else True)
+        uid1 = c1.send_command("load", {"file path": str(hello_file), "state": None})
+        uid2 = c2.send_command("load", {"file path": str(hello_file), "state": None})
+        actual1 = c1.wait_for_reply_to(uid1)
+        self.assertIn('result', actual1)
+        self.assertIn('state', actual1['result'])
+        state1 = actual1['result']['state']
+        actual2 = c2.wait_for_reply_to(uid2)
+        self.assertIn('result', actual2)
+        self.assertIn('state', actual2['result'])
+        state2 = actual2['result']['state']
+
+        # simple sleep for 3 seconds
+        t1 = time.time()
+        uid1 = c1.send_query("sleep", {"microseconds": 3000000, "state": state1})
+        actual1 = c1.wait_for_reply_to(uid1)
+        t2 = time.time()
+        self.assertIn('result', actual1)
+        if 'result' in actual1:
+            self.assertIn('state', actual1['result'])
+            self.assertIn('answer', actual1['result'])
+            if 'answer' in actual1['result']:
+                self.assertIn('value', actual1['result']['answer'])
+                if 'value' in actual1['result']['answer']:
+                    self.assertGreater(actual1['result']['answer']['value'], 2.9)
+        self.assertGreater(t2 - t1, 2.9)
+
+
+        # Sleep for 100 seconds, but then interrupt!
+        newpid = os.fork()
+        if newpid == 0:
+            time.sleep(3)
+            uid2 = c2.send_notification("interrupt", {})
+            os._exit(0)
+        else:
+            one_hundred_sec = 100000000
+            t1 = time.time()
+            uid1 = c1.send_query("sleep", {"microseconds": one_hundred_sec, "state": state1})
+
+        # check contents...?
+        uid1 = assertShow(self, c1, state=state1, expected='Hello World!\n')
+        uid2 = assertShow(self, c2, state=state2, expected='Hello World!\n')
+
+        # mutation/interrupt test
+        newpid = os.fork()
+        if newpid != 0:
+            # parent tries to clean up
+            two_sec = 2000000
+            t1 = time.time()
+            uid1 = c1.send_command("slow clear", {"pause microseconds": two_sec, "state": state1})
+        else:
+            # child allows cleanup to start but not finish
+            time.sleep(4)
+            uid2 = c2.send_notification("interrupt", {})
+            os._exit(0)
+
+        # check contents (N.B., there is no mutable state, so interrupts which stop a command mean
+        # the state is not updated by the argo server backend).
+        uid1 = assertShow(self, c1, state=state1, expected='Hello World!\n')
+        uid2 = assertShow(self, c2, state=state2, expected='Hello World!\n')

--- a/python/tests/test_mutable_file_echo_api.py
+++ b/python/tests/test_mutable_file_echo_api.py
@@ -26,6 +26,35 @@ def bad_state_res(*,uid,state):
     return r
 
 
+def assertShow(self : unittest.TestCase,
+               connection : argo.ServerConnection,
+               state : Optional[str],
+               expected : str,
+               *,
+               expected_equal : bool = True) -> Tuple[int, str]:
+    """Send a `show` command from `state` and ensure it returns `expected`.
+
+    Returns the request uid and state in a tuple."""
+
+    next_state = None
+    uid = connection.send_query("show", {"state": state})
+    actual = connection.wait_for_reply_to(uid)
+    self.assertIn('result', actual)
+    if 'result' in actual:
+        self.assertIn('state', actual['result'])
+        if 'state' in actual['result']:
+            next_state = actual['result']['state']
+        self.assertIn('answer', actual['result'])
+        if 'answer' in actual['result']:
+            self.assertIn('value', actual['result']['answer'])
+            if 'value' in actual['result']['answer']:
+                if expected_equal:
+                    self.assertEqual(actual['result']['answer']['value'], expected)
+                else:
+                    self.assertNotEqual(actual['result']['answer']['value'], expected)
+    return (uid, next_state)
+
+
 class MutableFileEchoTests(unittest.TestCase):
 
     @classmethod
@@ -54,34 +83,13 @@ class MutableFileEchoTests(unittest.TestCase):
         os.killpg(os.getpgid(self.p.pid), signal.SIGKILL)
         super().tearDownClass()
 
-    def assertShow(self, connection : argo.ServerConnection, state : Optional[str], expected : str) -> Tuple[int, str]:
-        """Send a `show` command from `state` and ensure it returns `expected`.
-        
-        Returns the request uid and state in a tuple."""
-
-        next_state = None
-        uid = connection.send_query("show", {"state": state})
-        actual = connection.wait_for_reply_to(uid)
-        self.assertIn('result', actual)
-        if 'result' in actual:
-            self.assertIn('state', actual['result'])
-            if 'state' in actual['result']:
-                next_state = actual['result']['state']
-            self.assertIn('answer', actual['result'])
-            if 'answer' in actual['result']:
-                self.assertIn('value', actual['result']['answer'])
-                if 'value' in actual['result']['answer']:
-                    self.assertEqual(actual['result']['answer']['value'], expected)
-        
-        return (uid, next_state)
-
 
     def test_subsequent_connection(self):
         c = argo.ServerConnection(argo.HttpProcess('http://localhost:8080/'))
         ## Positive tests -- make sure the server behaves as we expect with valid RPCs
 
         # [c] Check that their is nothing to show if we haven't loaded a file yet
-        (prev_uid, state) = self.assertShow(c, state=None,expected='')
+        (prev_uid, state) = assertShow(self, c, state=None,expected='')
 
         # [c] load a file
         hello_file = file_dir.joinpath('hello.txt')
@@ -97,13 +105,13 @@ class MutableFileEchoTests(unittest.TestCase):
         prev_uid = uid
 
         # [c] check the contents of the loaded file
-        (prev_uid, state) = self.assertShow(c, state=state,expected='Hello World!\n')
+        (prev_uid, state) = assertShow(self, c, state=state,expected='Hello World!\n')
 
         # [other_c] start a subsequent connection
         other_c = argo.ServerConnection(argo.HttpProcess('http://localhost:8080/'))
 
         # [other_c] check that the other connection has nothing to show if we haven't loaded our own file yet
-        (other_prev_uid, other_state) = self.assertShow(other_c, state=None,expected='')
+        (other_prev_uid, other_state) = assertShow(self, other_c, state=None,expected='')
 
 
         # [other_c] load a file
@@ -129,5 +137,104 @@ class MutableFileEchoTests(unittest.TestCase):
         self.assertNotEqual(other_uid, other_prev_uid)
 
         # [c] check the contents of the loaded file again in the original connection
-        (prev_uid, state) = self.assertShow(c, state=state,expected='Hello World!\n')
+        (prev_uid, state) = assertShow(self, c, state=state,expected='Hello World!\n')
 
+
+class InterruptTests(unittest.TestCase):
+    # Connection to server
+    c = None
+    # process running the server
+    p = None
+
+    @classmethod
+    def setUpClass(self):
+        p = subprocess.Popen(
+            ["cabal", "run", "exe:mutable-file-echo-api", "--verbose=0", "--", "--max-occupancy", "2", "http", "/", "--port", "8083", "--file", str(hello_file)],
+            stdout=subprocess.PIPE,
+            stdin=subprocess.DEVNULL,
+            stderr=subprocess.PIPE,
+            start_new_session=True)
+        time.sleep(3)
+        assert(p is not None)
+        poll_result = p.poll()
+        if poll_result is not None:
+            print(poll_result)
+            print(p.stdout.read())
+            print(p.stderr.read())
+        assert(poll_result is None)
+
+        self.p = p
+
+    @classmethod
+    def tearDownClass(self):
+        os.killpg(os.getpgid(self.p.pid), signal.SIGKILL)
+        super().tearDownClass()
+
+    # to be implemented by classes extending this one
+    def test_interrupts(self):
+        c1 = argo.ServerConnection(argo.HttpProcess('http://localhost:8083/'))
+        c2 = argo.ServerConnection(argo.HttpProcess('http://localhost:8083/'))
+        # load a file
+        hello_file = file_dir.joinpath('hello.txt')
+        self.assertTrue(False if not hello_file.is_file() else True)
+        uid1 = c1.send_command("load", {"file path": str(hello_file), "state": None})
+        uid2 = c2.send_command("load", {"file path": str(hello_file), "state": None})
+        actual1 = c1.wait_for_reply_to(uid1)
+        self.assertIn('result', actual1)
+        self.assertIn('state', actual1['result'])
+        state1 = actual1['result']['state']
+        actual2 = c2.wait_for_reply_to(uid2)
+        self.assertIn('result', actual2)
+        self.assertIn('state', actual2['result'])
+        state2 = actual2['result']['state']
+
+        # simple sleep for 3 seconds
+        t1 = time.time()
+        uid1 = c1.send_query("sleep", {"microseconds": 3000000, "state": state1})
+        actual1 = c1.wait_for_reply_to(uid1)
+        t2 = time.time()
+        self.assertIn('result', actual1)
+        if 'result' in actual1:
+            self.assertIn('state', actual1['result'])
+            self.assertIn('answer', actual1['result'])
+            if 'answer' in actual1['result']:
+                self.assertIn('value', actual1['result']['answer'])
+                if 'value' in actual1['result']['answer']:
+                    self.assertGreater(actual1['result']['answer']['value'], 2.9)
+        self.assertGreater(t2 - t1, 2.9)
+
+
+        # sleep/interrupt test
+        newpid = os.fork()
+        if newpid != 0:
+            # parent tries to sleep
+            one_hundred_sec = 100000000
+            t1 = time.time()
+            uid1 = c1.send_query("sleep", {"microseconds": one_hundred_sec, "state": state1})
+            t2 = time.time()
+        else:
+            # child does not allow sleep
+            time.sleep(3)
+            uid2 = c2.send_notification("interrupt", {})
+            os._exit(0)
+        # check interrupt actually interrupted 100sec sleep
+        self.assertLess(t2 - t1, 10)
+
+        # mutation/interrupt test
+        newpid = os.fork()
+        if newpid != 0:
+            # parent tries to clean up
+            two_sec = 2000000
+            t1 = time.time()
+            uid1 = c1.send_command("slow clear", {"pause microseconds": two_sec, "state": state1})
+        else:
+            # child allows cleanup to start but not finish
+            time.sleep(4)
+            uid2 = c2.send_notification("interrupt", {})
+            os._exit(0)
+
+        # check contents (N.B., the mutable server uses an IORef for the
+        # contents, so the interrupt doesn't prevent effects.)
+        (uid1, state1) = assertShow(self, c1, state=state1, expected='Hello World!\n', expected_equal = False)
+        (uid1, state1) = assertShow(self, c1, state=state1, expected='', expected_equal = False)
+        (uid2, state2) = assertShow(self, c2, state=state2, expected='Hello World!\n')


### PR DESCRIPTION
This PR adds the ability to interrupt all active threads serving requests in the server.

Design notes:
+ For simplicity's sake, an interrupt is a server-wide event and cannot target specific requests. This seems reasonable as an initial constraint given that the `MVars` guarding the server state currently only allow one active request at a time. I.e., things are already fairly linear already so this shouldn't complicate any workflows.
+ For servers with *immutable state*, active requests which are cancelled have no observable effects since the updated state is only recorded upon completion of the request.
+ For servers with *mutable state* (or mutable _portions_ of state), effects (i.e., `IO`) from an interrupted thread may be observed since they cannot be rolled back in any meaningful way, however, the overall state (i.e., any immutable portions) will remain untouched for the same reason noted above.
+ `killThread` is currently used to kill all the active threads in the server. It is not clear how nicely this will interact with the Cryptol/SAW servers yet... in particular, killing a thread in this manner may leave lingering resources (e.g., external processes spawned by said thread) -- will have to follow up on this concern as we look to integrate the feature into the `cryptol-remote-api`

This should partially address https://github.com/GaloisInc/cryptol/issues/1147 i.e., we can interrupt long running commands, however, timeouts still need to be added separately.
