### PR TITLE
feat: server and client logging options for RPC tx/rx

### DIFF
--- a/argo/src/Argo.hs
+++ b/argo/src/Argo.hs
@@ -1136,7 +1136,7 @@ serveHttp opts httpOpts app port = do
                             then status204
                             else ok200
                    liftIO $ if body == ""
-                            then logTx opts "[TX] 'NO CONTENT'"
+                            then logTx opts "'NO CONTENT'"
                             else logTx opts body
                    raw body
        -- Return a more informative status code when the wrong HTTP method is used

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -1,3 +1,7 @@
+# argo-client v0.0.6 (22 Jul 2021)
++ Add logging option to client. See `ServerProcess.logging(..)` and
+  `ServerConnection.logging(..)`.
+
 # argo-client v0.0.5 (23 Jun 2021)
 + Add HTTP flag for TLS cert verification options.
 

--- a/python/argo_client/connection.py
+++ b/python/argo_client/connection.py
@@ -72,11 +72,6 @@ class ServerProcess(metaclass=ABCMeta):
     @abstractmethod
     def send_one_message(self, the_message: str, *, expecting_response : bool = True) -> None: pass
 
-    @abstractmethod
-    def logging(self, on : bool, *, dest : TextIO = sys.stderr) -> None:
-        """Whether to log received and transmitted JSON."""
-        pass
-
     def logging(self, on : bool, *, dest : TextIO = sys.stderr) -> None:
         """Whether to log received and transmitted JSON."""
         if on:

--- a/python/argo_client/connection.py
+++ b/python/argo_client/connection.py
@@ -79,11 +79,11 @@ class ServerProcess(metaclass=ABCMeta):
         else:
             self._logging_dest = None
 
-    def _log_tx(self, contents : str):
+    def _log_tx(self, contents : str) -> None:
         if self._logging_dest:
             self._logging_dest.write("[TX] " + contents.strip() + "\n")
 
-    def _log_rx(self, contents : str):
+    def _log_rx(self, contents : str) -> None:
         if self._logging_dest:
             self._logging_dest.write("[RX] " + contents.strip() + "\n")
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -12,7 +12,7 @@ def get_README():
 setup(
     name="argo-client",
     python_requires=">=3.7",
-    version="0.0.5",
+    version="0.0.6",
     url="https://github.com/GaloisInc/argo",
     project_urls={
         "Changelog": "https://github.com/GaloisInc/argo/blob/master/python/CHANGELOG.md",

--- a/python/tests/test_file_echo_api.py
+++ b/python/tests/test_file_echo_api.py
@@ -1,3 +1,4 @@
+from json.decoder import JSONDecodeError
 import os
 from pathlib import Path
 import requests
@@ -6,6 +7,7 @@ import time
 import json
 import unittest
 import signal
+import io
 from typing import Optional, Tuple
 
 import argo_client.connection as argo
@@ -71,10 +73,13 @@ class GenericFileEchoTests():
     # to be implemented by classes extending this one
     def get_connection(self): pass
     def get_caching_iterations(self): pass
+    def get_server_log_file(self): pass
 
 
     def test_basics(self):
         c = self.get_connection()
+        log_buffer = io.StringIO()
+        c.logging(on=True, dest=log_buffer)
         ## Positive tests -- make sure the server behaves as we expect with valid RPCs
 
         # Check that their is nothing to show if we haven't loaded a file yet
@@ -116,6 +121,28 @@ class GenericFileEchoTests():
         # check that the file contents cleared
         prev_uid = assertShow(self, c, state=prev_state, expected='')
 
+        # check logger output
+        self.check_log_contents(log_buffer.getvalue().splitlines())
+        self.check_log_contents(list(open(self.get_server_log_file())))
+
+    def check_log_contents(self, lines):
+        """Check that the list of logged lines is non-empty and conforms to our
+        expected shape (i.e., either ``CONNECT: PORT_INFO``, ``[RX] JSON``, or
+        ``[TX] JSON``."""
+        self.assertNotEqual(lines, [])
+        for line in lines:
+            [header, content] = line.strip().split(' ', 1)
+            self.assertIn(header, {'[TX]','[RX]','CONNECT:'})
+            if header != 'CONNECT:':
+                try:
+                    json.loads(content)
+                except json.JSONDecodeError:
+                    self.fail(f'logger produced non-JSON contents: {line}')
+
+
+    def test_errors(self):
+        c = self.get_connection()
+        prev_state = None
         ## Negative tests -- make sure the server errors as we expect
 
         # Method not found
@@ -168,7 +195,6 @@ class GenericFileEchoTests():
         expected = {'error':{'data':{'stdout':None,'data':'Error in $: Failed reading: not a valid json value at \'BAAAAADJSON\'','stderr':None},'code':-32700,'message':'Parse error'},'jsonrpc':'2.0','id':None}
         self.assertEqual(actual, expected)
 
-
 class RemoteSocketProcessTests(GenericFileEchoTests, unittest.TestCase):
     # Connection to cryptol
     c = None
@@ -178,7 +204,7 @@ class RemoteSocketProcessTests(GenericFileEchoTests, unittest.TestCase):
     @classmethod
     def setUpClass(self):
         p = subprocess.Popen(
-            ["cabal", "run", "exe:file-echo-api", "--verbose=0", "--", "socket", "--port", "50005"],
+            ["cabal", "run", "exe:file-echo-api", "--verbose=0", "--", "socket", "--port", "50005", "--log", "remote-socket-server.log"],
             stdout=subprocess.PIPE,
             stdin=subprocess.DEVNULL,
             stderr=subprocess.PIPE,
@@ -201,13 +227,16 @@ class RemoteSocketProcessTests(GenericFileEchoTests, unittest.TestCase):
         os.killpg(os.getpgid(self.p.pid), signal.SIGKILL)
         super().tearDownClass()
 
-
     # to be implemented by classes extending this one
     def get_connection(self):
         return self.c
 
     def get_caching_iterations(self):
         return 30
+
+    def get_server_log_file(self):
+        return "remote-socket-server.log"
+
 
 class DynamicSocketProcessTests(GenericFileEchoTests, unittest.TestCase):
     # Connection to server
@@ -216,7 +245,7 @@ class DynamicSocketProcessTests(GenericFileEchoTests, unittest.TestCase):
     @classmethod
     def setUpClass(self):
         self.c = argo.ServerConnection(
-                    argo.DynamicSocketProcess("cabal run exe:file-echo-api --verbose=0 -- socket --port 50006"))
+                    argo.DynamicSocketProcess(f'cabal run exe:file-echo-api --verbose=0 -- socket --port 50006 --log dynamic-socket-server.log'))
 
     # to be implemented by classes extending this one
     def get_connection(self):
@@ -225,6 +254,9 @@ class DynamicSocketProcessTests(GenericFileEchoTests, unittest.TestCase):
     def get_caching_iterations(self):
         return 30
 
+    def get_server_log_file(self):
+        return "dynamic-socket-server.log"
+
 class StdIOProcessTests(GenericFileEchoTests, unittest.TestCase):
     # Connection to server
     c = None
@@ -232,13 +264,16 @@ class StdIOProcessTests(GenericFileEchoTests, unittest.TestCase):
     @classmethod
     def setUpClass(self):
         self.c = argo.ServerConnection(
-                    argo.StdIOProcess("cabal run exe:file-echo-api --verbose=0 -- stdio"))
+                    argo.StdIOProcess(f'cabal run exe:file-echo-api --verbose=0 -- stdio --log stdio-server.log'))
 
     def get_connection(self):
         return self.c
 
     def get_caching_iterations(self):
         return 30
+
+    def get_server_log_file(self):
+        return "stdio-server.log"
 
 
 class HttpTests(GenericFileEchoTests, unittest.TestCase):
@@ -250,7 +285,7 @@ class HttpTests(GenericFileEchoTests, unittest.TestCase):
     @classmethod
     def setUpClass(self):
         p = subprocess.Popen(
-            ["cabal", "run", "exe:file-echo-api", "--verbose=0", "--", "http", "/", "--port", "8080"],
+            ["cabal", "run", "exe:file-echo-api", "--verbose=0", "--", "http", "/", "--port", "8080", "--log", "http-server.log"],
             stdout=subprocess.PIPE,
             stdin=subprocess.DEVNULL,
             stderr=subprocess.PIPE,
@@ -278,6 +313,9 @@ class HttpTests(GenericFileEchoTests, unittest.TestCase):
 
     def get_caching_iterations(self):
         return 30
+
+    def get_server_log_file(self):
+        return "http-server.log"
 
     def test_http_behaviors(self):
         ### Additional tests for the HTTP server ###
@@ -321,7 +359,7 @@ class TLSTests1(GenericFileEchoTests, unittest.TestCase):
         server_env = os.environ.copy()
         server_env["TLS_ENABLE"] = "1"
         p = subprocess.Popen(
-            ["cabal", "run", "exe:file-echo-api", "--verbose=0", "--", "http", "/", "--port", "8083"],
+            ["cabal", "run", "exe:file-echo-api", "--verbose=0", "--", "http", "/", "--port", "8083", "--log", "tls1-server.log"],
             stdout=subprocess.PIPE,
             stdin=subprocess.DEVNULL,
             stderr=subprocess.PIPE,
@@ -351,6 +389,9 @@ class TLSTests1(GenericFileEchoTests, unittest.TestCase):
     def get_caching_iterations(self):
         return 30
 
+    def get_server_log_file(self):
+        return "tls1-server.log"
+
 class TLSTests2(GenericFileEchoTests, unittest.TestCase):
     # Connection to server
     c = None
@@ -363,7 +404,7 @@ class TLSTests2(GenericFileEchoTests, unittest.TestCase):
                   + ' -subj "/C=GB/ST=London/L=London/O=Acme Widgets/OU=IT Department/CN=localhost"')
         os.system('openssl x509 -req -days 365 -in server.csr -signkey server.key -out server.crt')
         p = subprocess.Popen(
-            ["cabal", "run", "exe:file-echo-api", "--verbose=0", "--", "http", "/", "--port", "8083", "--tls"],
+            ["cabal", "run", "exe:file-echo-api", "--verbose=0", "--", "http", "/", "--port", "8083", "--tls", "--log", "tls2-server.log"],
             stdout=subprocess.PIPE,
             stdin=subprocess.DEVNULL,
             stderr=subprocess.PIPE,
@@ -392,6 +433,10 @@ class TLSTests2(GenericFileEchoTests, unittest.TestCase):
     def get_caching_iterations(self):
         return 30
 
+    @classmethod
+    def get_server_log_file(self):
+        return "tls2-server.log"
+
 class LoadOnLaunchTests(unittest.TestCase):
     # Connection to server
     c = None
@@ -401,7 +446,8 @@ class LoadOnLaunchTests(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         p = subprocess.Popen(
-            ["cabal", "run", "exe:file-echo-api", "--verbose=0", "--", "http", "/", "--port", "8081", "--file", str(hello_file)],
+            ["cabal", "run", "exe:file-echo-api", "--verbose=0", "--", "http", "/", "--port"
+            , "8081", "--file", str(hello_file), "--log", "load-on-launch-server.log"],
             stdout=subprocess.PIPE,
             stdin=subprocess.DEVNULL,
             stderr=subprocess.PIPE,
@@ -433,6 +479,8 @@ class LoadOnLaunchTests(unittest.TestCase):
         expected = {'result':{'state':actual['result']['state'],'stdout':'','stderr':'','answer':{'value':'Hello World!\n'}},'jsonrpc':'2.0','id':uid}
         self.assertEqual(actual, expected)
 
+    def get_server_log_file(self):
+        return "load-on-launch-server.log"
 
 class OccupancyTests(unittest.TestCase):
     # Connection to server
@@ -443,7 +491,8 @@ class OccupancyTests(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         p = subprocess.Popen(
-            ["cabal", "run", "exe:file-echo-api", "--verbose=0", "--", "--max-occupancy", "2", "http", "/", "--port", "8082", "--file", str(hello_file)],
+            ["cabal", "run", "exe:file-echo-api", "--verbose=0", "--", "--max-occupancy"
+            , "2", "http", "/", "--port", "8082", "--file", str(hello_file)],
             stdout=subprocess.PIPE,
             stdin=subprocess.DEVNULL,
             stderr=subprocess.PIPE,


### PR DESCRIPTION
This PR adds basic logging which can be toggled for both the argo client 
and server, s.t. each RPC transmission (TX) and reception (RX) is emitted
on a single line to the specified file/handle.

Tests ensuring this works as expected for each transport method available
have also been added to the python test suite.

The underlying goal here is to make it easier to debug server/client interactions
(especially in non-trivial deployment situations).

Any feedback/critique/etc on logging techniques used (e.g., is writing to a file
with `Text.appendFile` reasonable for file logging? etc) welcome!