### PR TITLE
Improve client error recovery

### DIFF
--- a/python/argo_client/interaction.py
+++ b/python/argo_client/interaction.py
@@ -137,6 +137,18 @@ class Command(Interaction):
     corresponding command's appropriate representation.
     """
 
+    def state(self) -> Any:
+        """Return the protocol state after the command is complete if the
+        command did not error, or the protocol state prior to the the command
+        otherwise."""
+        res = self.raw_result()
+        if 'error' in res:
+            return self.init_state
+        elif 'result' in res:
+            return res['result']['state']
+        else:
+            raise ValueError("Invalid result type from JSON RPC")
+
     def _result_and_state_and_out_err(self) -> Tuple[Any, Any, str, str]:
         res = self.raw_result()
         if 'error' in res:
@@ -158,10 +170,6 @@ class Command(Interaction):
                     res['result']['stderr'])
         else:
             raise ValueError("Invalid result type from JSON RPC")
-
-    def state(self) -> Any:
-        """Return the protocol state after the command is complete."""
-        return self._result_and_state_and_out_err()[1]
 
     def result(self) -> Any:
         """Return the result of the command."""

--- a/python/tests/test_file_echo_interaction.py
+++ b/python/tests/test_file_echo_interaction.py
@@ -224,7 +224,8 @@ class CommandErrorInteractionTests5(unittest.TestCase):
     def setUpClass(self):
         p = subprocess.Popen(
             ["cabal", "run", "exe:file-echo-api", "--verbose=0", "--",
-            "socket", "--port", "50005", "--log", "stderr"],
+             "socket", "--port", "50005" #, "--log", "stderr"
+            ], # Uncomment the above for debug output
             stdout=subprocess.PIPE,
             stdin=subprocess.DEVNULL,
             #stderr=subprocess.PIPE,
@@ -250,7 +251,7 @@ class CommandErrorInteractionTests5(unittest.TestCase):
 
     def test_load_after_implosion(self):
         c = self.c
-        self.c.logging(True)
+        self.c.logging(False) # Change this to 'True' for debug output
 
         # test that internal errors without extra data raise proper exceptions
         with self.assertRaises(ArgoException):

--- a/python/tests/test_file_echo_interaction.py
+++ b/python/tests/test_file_echo_interaction.py
@@ -1,10 +1,15 @@
 import os
 import unittest
 import argo_client.interaction as argo
+import argo_client.connection as argo_conn
 from pathlib import Path
 from argo_client.interaction import HasProtocolState, ArgoException
 from argo_client.connection import ServerConnection, StdIOProcess
-from typing import Any, Optional
+from typing import Any, Optional, TextIO
+import sys
+import signal
+import time
+import subprocess
 
 class LoadFile(argo.Command):
     def __init__(self, connection : HasProtocolState, file_path : str) -> None:
@@ -74,6 +79,10 @@ class FileEchoConnection:
         """Reset the underlying server state."""
         Reset(self)
         self.most_recent_result = None
+
+    def logging(self, on : bool, *, dest : TextIO = sys.stderr) -> None:
+        """Whether to log received and transmitted JSON."""
+        self.server_connection.logging(on=on,dest=dest)
 
 dir_path = Path(os.path.dirname(os.path.realpath(__file__)))
 file_dir = dir_path.joinpath('test-data')
@@ -174,27 +183,6 @@ class CommandErrorInteractionTests3(unittest.TestCase):
             c.implode().result()
 
 
-class CommandErrorInteractionTests4(unittest.TestCase):
-    # Connection to server
-    c : FileEchoConnection = None
-
-    @classmethod
-    def setUpClass(self):
-        self.c = FileEchoConnection(
-                    argo.ServerConnection(
-                        StdIOProcess(
-                            "cabal run exe:file-echo-api --verbose=0 -- stdio")))
-
-    def test_load_after_reset(self):
-        c = self.c
-
-        hello_file = file_dir.joinpath('hello.txt')
-        self.assertTrue(False if not hello_file.is_file() else True)
-
-        # test loading and showing a valid file
-        c.load_file(str(hello_file))
-        self.assertEqual(c.show().result(), "Hello World!\n")
-
         c.reset()
 
         # post reset connection is in initial state
@@ -205,3 +193,54 @@ class CommandErrorInteractionTests4(unittest.TestCase):
         self.assertTrue(False if not base_file.is_file() else True)
         c.load_file(str(base_file))
         self.assertEqual(c.show().result(), "All your base are belong to us!\n")
+
+class CommandErrorInteractionTests5(unittest.TestCase):
+    # Connection to server
+    c : FileEchoConnection = None
+
+    @classmethod
+    def setUpClass(self):
+        p = subprocess.Popen(
+            ["cabal", "run", "exe:file-echo-api", "--verbose=0", "--",
+            "socket", "--port", "50005", "--log", "stderr"],
+            stdout=subprocess.PIPE,
+            stdin=subprocess.DEVNULL,
+            #stderr=subprocess.PIPE,
+            stderr=sys.stdout,
+            start_new_session=True)
+        time.sleep(3)
+        assert(p is not None)
+        poll_result = p.poll()
+        if poll_result is not None:
+            print(poll_result)
+            print(p.stdout.read())
+            print(p.stderr.read())
+        assert(poll_result is None)
+
+        self.p = p
+        self.c = FileEchoConnection(
+                    argo_conn.ServerConnection(
+                        argo_conn.RemoteSocketProcess('localhost', 50005, ipv6=True)))
+
+
+    @classmethod
+    def tearDownClass(self):
+        os.killpg(os.getpgid(self.p.pid), signal.SIGKILL)
+        super().tearDownClass()
+
+    def test_load_after_implosion(self):
+        c = self.c
+        self.c.logging(True)
+
+        # test that internal errors without extra data raise proper exceptions
+        with self.assertRaises(ArgoException):
+            c.implode().result()
+
+        c.reset()
+
+        hello_file = file_dir.joinpath('hello.txt')
+        self.assertTrue(False if not hello_file.is_file() else True)
+
+        # test loading and showing a valid file
+        c.load_file(str(hello_file))
+        self.assertEqual(c.show().result(), "Hello World!\n")

--- a/python/tests/test_file_echo_interaction.py
+++ b/python/tests/test_file_echo_interaction.py
@@ -256,11 +256,13 @@ class CommandErrorInteractionTests5(unittest.TestCase):
         with self.assertRaises(ArgoException):
             c.implode().result()
 
-        c.reset()
-
         hello_file = file_dir.joinpath('hello.txt')
         self.assertTrue(False if not hello_file.is_file() else True)
 
-        # test loading and showing a valid file
+        # test that loading and showing a valid file still works after an
+        # exception
         c.load_file(str(hello_file))
         self.assertEqual(c.show().result(), "Hello World!\n")
+
+        # test that a reset still works after an exception
+        c.reset()

--- a/python/tests/test_file_echo_interaction.py
+++ b/python/tests/test_file_echo_interaction.py
@@ -183,6 +183,27 @@ class CommandErrorInteractionTests3(unittest.TestCase):
             c.implode().result()
 
 
+class CommandErrorInteractionTests4(unittest.TestCase):
+    # Connection to server
+    c : FileEchoConnection = None
+
+    @classmethod
+    def setUpClass(self):
+        self.c = FileEchoConnection(
+                    argo.ServerConnection(
+                        StdIOProcess(
+                            "cabal run exe:file-echo-api --verbose=0 -- stdio")))
+
+    def test_load_after_reset(self):
+        c = self.c
+
+        hello_file = file_dir.joinpath('hello.txt')
+        self.assertTrue(False if not hello_file.is_file() else True)
+
+        # test loading and showing a valid file
+        c.load_file(str(hello_file))
+        self.assertEqual(c.show().result(), "Hello World!\n")
+
         c.reset()
 
         # post reset connection is in initial state
@@ -193,6 +214,7 @@ class CommandErrorInteractionTests3(unittest.TestCase):
         self.assertTrue(False if not base_file.is_file() else True)
         c.load_file(str(base_file))
         self.assertEqual(c.show().result(), "All your base are belong to us!\n")
+
 
 class CommandErrorInteractionTests5(unittest.TestCase):
     # Connection to server
@@ -216,12 +238,10 @@ class CommandErrorInteractionTests5(unittest.TestCase):
             print(p.stdout.read())
             print(p.stderr.read())
         assert(poll_result is None)
-
         self.p = p
         self.c = FileEchoConnection(
                     argo_conn.ServerConnection(
                         argo_conn.RemoteSocketProcess('localhost', 50005, ipv6=True)))
-
 
     @classmethod
     def tearDownClass(self):


### PR DESCRIPTION
Changes the behavior of the `state` method of `Command` to return the last valid state in the event of an error. This fixes a bug where once a connection encounters an erroring command, all subsequent interactions throw the same error – see #180 for more detail.