### PR TITLE
feat: notifications delay new request handling while running

### DIFF
--- a/argo/src/Argo.hs
+++ b/argo/src/Argo.hs
@@ -906,8 +906,6 @@ handleRequest opts respond app req = do
               return $ addStateID stateID result
       respond (JSON.encode response)
     Just (NotificationMethod m) -> do
-      -- Acquire the request lock so _new_ requests cannot be served
-      -- while the notification is executing.
       withoutRequestID $ withoutStateID $ do
         let nctx = NotificationContext
                     { ntfCtxMOptions = opts

--- a/argo/src/Argo.hs
+++ b/argo/src/Argo.hs
@@ -870,6 +870,9 @@ handleRequest opts respond app req = do
     Just (CommandMethod m) -> withActiveThread app $ withRequestID $ \reqID -> do
       stateID <- getStateID req
       response <- withMVar theState $ \state -> do
+        -- N.B., the server is not "full" if `stateID == initialStateID`
+        -- because `stateID` will be evicted/destroyed once it is
+        -- used to create a new `stateID'`
         serverFull <- do cnt <- statePoolCount state
                          pure $ cnt >= (optMaxOccupancy opts)
                                 && stateID == initialStateID

--- a/argo/src/Argo/DefaultMain.hs
+++ b/argo/src/Argo/DefaultMain.hs
@@ -281,6 +281,10 @@ readOnlyOpt =
    (Opt.long "read-only" <>
     Opt.help "Do not generate any output files, for use on a read-only file system."))
 
+-- | Controls the maximum number of live states the server can maintain at once before
+-- either rejecting new connection's which create fresh states or evicting the oldest
+-- state. The default behavior is the latter (evict older states), but the former
+-- behavior can be selected via the `noEvictionOpt` option.
 maxOccupancyOpt :: Opt.Parser Natural
 maxOccupancyOpt =
   (Opt.option Opt.auto

--- a/file-echo-api/file-echo-api/Main.hs
+++ b/file-echo-api/file-echo-api/Main.hs
@@ -62,8 +62,9 @@ serverMethods =
   , Argo.query "implode" (Doc.Paragraph [Doc.Text "Throw an error immediately."]) FES.implodeCmd
   , Argo.query "show" (Doc.Paragraph [Doc.Text "Show a substring of the file."]) FES.showCmd
   , Argo.query "ignore" (Doc.Paragraph [Doc.Text "Ignore an ", Doc.Link (Doc.TypeDesc (typeRep (Proxy @FES.Ignorable))) "ignorable value", Doc.Text "."]) FES.ignoreCmd
-  , Argo.query "sleep" (Doc.Paragraph [Doc.Text "Sleep for a specified number of microseconds."]) FES.sleepQuery
+  , Argo.query "sleep query" (Doc.Paragraph [Doc.Text "Sleep for a specified number of microseconds."]) FES.sleepQuery
   , Argo.notification "destroy state" (Doc.Paragraph [Doc.Text "Destroy a state in the server."]) FES.destroyState
   , Argo.notification "destroy all states" (Doc.Paragraph [Doc.Text "Destroy all states in the server."]) FES.destroyAllStates
   , Argo.notification "interrupt" (Doc.Paragraph [Doc.Text "Interrupt all threads in the server."]) FES.interruptAllThreads
+  , Argo.notification "sleep notification" (Doc.Paragraph [Doc.Text "Sleep for a specified number of microseconds."]) FES.sleepNotification
   ]

--- a/file-echo-api/mutable-file-echo-api/Main.hs
+++ b/file-echo-api/mutable-file-echo-api/Main.hs
@@ -56,7 +56,7 @@ serverMethods =
   , Argo.command "clear" (Doc.Paragraph [Doc.Text "Forget the loaded file."]) MFES.clearCmd
   , Argo.command "slow clear" (Doc.Paragraph [Doc.Text "Forgets the loaded file slowly (i.e., char by char)."]) MFES.slowClear
   , Argo.query "show" (Doc.Paragraph [Doc.Text "Show a substring of the file."]) MFES.showCmd
-  , Argo.query "sleep" (Doc.Paragraph [Doc.Text "Sleep for a specified number of microseconds."]) MFES.sleepQuery
+  , Argo.query "sleep query" (Doc.Paragraph [Doc.Text "Sleep for a specified number of microseconds."]) MFES.sleepQuery
   , Argo.notification "destroy state" (Doc.Paragraph [Doc.Text "Destroy a state."]) MFES.destroyState
   , Argo.notification "interrupt" (Doc.Paragraph [Doc.Text "Interrupt all threads in the server."]) MFES.interruptAllThreads
   ]

--- a/file-echo-api/src/FileEchoServer.hs
+++ b/file-echo-api/src/FileEchoServer.hs
@@ -293,14 +293,14 @@ destroyAllStates _ = Argo.destroyAllStates
 ------------------------------------------------------------------------
 -- Sleep Query
 
-newtype SleepParams = SleepParams Int
+newtype SleepQueryParams = SleepQueryParams Int
 
-instance JSON.FromJSON SleepParams where
+instance JSON.FromJSON SleepQueryParams where
   parseJSON =
-    JSON.withObject "params for \"sleep\"" $
-    \o -> SleepParams <$> o .: "microseconds"
+    JSON.withObject "params for \"sleep query\"" $
+    \o -> SleepQueryParams <$> o .: "microseconds"
 
-instance Doc.DescribedMethod SleepParams JSON.Value where
+instance Doc.DescribedMethod SleepQueryParams JSON.Value where
   parameterFieldDescription =
     [("microseconds",
       Doc.Paragraph [Doc.Text "The duration to sleep in microseconds."])]
@@ -310,14 +310,30 @@ instance Doc.DescribedMethod SleepParams JSON.Value where
       Doc.Paragraph [ Doc.Text "Duration in seconds sleep lasted."])
     ]
 
-sleepQuery :: SleepParams -> Argo.Query ServerState JSON.Value
-sleepQuery (SleepParams ms) = liftIO $ do
+sleepQuery :: SleepQueryParams -> Argo.Query ServerState JSON.Value
+sleepQuery (SleepQueryParams ms) = liftIO $ do
   t1 <- round `fmap` getPOSIXTime
   threadDelay ms
   t2 <- round `fmap` getPOSIXTime
   pure (JSON.object [ "value" .= (JSON.Number (scientific (t2 - t1) 0))])
 
+------------------------------------------------------------------------
+-- Sleep Notification
 
+newtype SleepNotificationParams = SleepNotificationParams Int
+
+instance JSON.FromJSON SleepNotificationParams where
+  parseJSON =
+    JSON.withObject "params for \"sleep notification\"" $
+    \o -> SleepNotificationParams <$> o .: "microseconds"
+
+instance Doc.DescribedMethod SleepNotificationParams () where
+  parameterFieldDescription =
+    [("microseconds",
+      Doc.Paragraph [Doc.Text "The duration to sleep in microseconds."])]
+
+sleepNotification :: SleepNotificationParams -> Argo.Notification ()
+sleepNotification (SleepNotificationParams ms) = liftIO $ threadDelay ms
 
 ------------------------------------------------------------------------
 -- Interrupt All Threads Command

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -1,3 +1,8 @@
+# argo-client v0.0.8 (27 Aug 2021)
++ Improvements related to notification/request interference
+  (i.e., when a single client sends a notification immediately
+   followed by a request).
+
 # argo-client v0.0.7 (25 Aug 2021)
 + Change the behavior of the `Command` `state` method so that after a `Command`
   raises an exception, subsequent interactions will not also raise the same

--- a/python/argo_client/connection.py
+++ b/python/argo_client/connection.py
@@ -11,6 +11,7 @@ import requests
 import socket
 import subprocess
 import signal
+import time
 import threading
 import sys
 from typing import Any, Dict, List, IO, Mapping, Optional, Union, TextIO
@@ -472,6 +473,11 @@ class ServerConnection:
                'params': params}
         msg_string = json.dumps(msg)
         self.process.send_one_message(msg_string, expecting_response = False)
+        # Since notifications require no response and can interrupt commands/queries,
+        # they can sometimes interrupt subsequent requests. We have tried to guarantee
+        # in-order servicing on the server. This short pause is an additional small
+        # safety measure to keep things running smoothly.
+        time.sleep(0.1)
 
     def wait_for_reply_to(self, request_id: int) -> Any:
         """Block until a reply is received for the given

--- a/python/argo_client/connection.py
+++ b/python/argo_client/connection.py
@@ -473,11 +473,6 @@ class ServerConnection:
                'params': params}
         msg_string = json.dumps(msg)
         self.process.send_one_message(msg_string, expecting_response = False)
-        # Since notifications require no response and can interrupt commands/queries,
-        # they can sometimes interrupt subsequent requests. We have tried to guarantee
-        # in-order servicing on the server. This short pause is an additional small
-        # safety measure to keep things running smoothly.
-        time.sleep(0.1)
 
     def wait_for_reply_to(self, request_id: int) -> Any:
         """Block until a reply is received for the given

--- a/python/setup.py
+++ b/python/setup.py
@@ -12,7 +12,7 @@ def get_README():
 setup(
     name="argo-client",
     python_requires=">=3.7",
-    version="0.0.7",
+    version="0.0.8",
     url="https://github.com/GaloisInc/argo",
     project_urls={
         "Changelog": "https://github.com/GaloisInc/argo/blob/master/python/CHANGELOG.md",

--- a/python/tests/test_file_echo_api.py
+++ b/python/tests/test_file_echo_api.py
@@ -411,7 +411,7 @@ class TLSTests2(GenericFileEchoTests, unittest.TestCase):
     # process running the server
     p = None
     # port for the HTTP connection
-    port = "8084"
+    port = "8085"
 
     @classmethod
     def setUpClass(self):
@@ -459,7 +459,7 @@ class LoadOnLaunchTests(unittest.TestCase):
     # process running the server
     p = None
     # port for the HTTP connection
-    port = "8085"
+    port = "8086"
 
     @classmethod
     def setUpClass(self):
@@ -508,7 +508,7 @@ class Occupancy1Tests(unittest.TestCase):
     # process running the server
     p = None
     # port for the HTTP connection
-    port = "8086"
+    port = "8087"
 
     @classmethod
     def setUpClass(self):
@@ -554,7 +554,7 @@ class OccupancyNoEvictTests(unittest.TestCase):
     c = None
     # process running the server
     p = None
-    port = "8087"
+    port = "8088"
 
     @classmethod
     def setUpClass(self):
@@ -663,7 +663,7 @@ class InterruptTests(unittest.TestCase):
     c = None
     # process running the server
     p = None
-    port = "8088"
+    port = "8089"
 
     @classmethod
     def setUpClass(self):

--- a/python/tests/test_file_echo_api.py
+++ b/python/tests/test_file_echo_api.py
@@ -250,7 +250,7 @@ class DynamicSocketProcessTests(GenericFileEchoTests, unittest.TestCase):
     @classmethod
     def setUpClass(self):
         self.c = argo.ServerConnection(
-                    argo.DynamicSocketProcess(f'cabal run exe:file-echo-api --verbose=0 -- socket --port 50006 --log {DynamicSocketProcessTests.server_log_file()}'))
+                    argo.DynamicSocketProcess(f'cabal run exe:file-echo-api --verbose=0 -- socket --log {DynamicSocketProcessTests.server_log_file()}'))
 
     # to be implemented by classes extending this one
     def get_connection(self):

--- a/python/tests/test_mutable_file_echo_api.py
+++ b/python/tests/test_mutable_file_echo_api.py
@@ -60,7 +60,7 @@ class MutableFileEchoTests(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         p = subprocess.Popen(
-            ["cabal", "run", "exe:mutable-file-echo-api", "--verbose=0", "--", "http", "/", "--port", "8080"],
+            ["cabal", "run", "exe:mutable-file-echo-api", "--verbose=0", "--", "--max-occupancy", "2", "http", "/", "--port", "8080"],
             stdout=subprocess.PIPE,
             stdin=subprocess.DEVNULL,
             stderr=subprocess.PIPE,

--- a/python/tests/test_mutable_file_echo_api.py
+++ b/python/tests/test_mutable_file_echo_api.py
@@ -190,7 +190,7 @@ class InterruptTests(unittest.TestCase):
 
         # simple sleep for 3 seconds
         t1 = time.time()
-        uid1 = c1.send_query("sleep", {"microseconds": 3000000, "state": state1})
+        uid1 = c1.send_query("sleep query", {"microseconds": 3000000, "state": state1})
         actual1 = c1.wait_for_reply_to(uid1)
         t2 = time.time()
         self.assertIn('result', actual1)
@@ -210,7 +210,7 @@ class InterruptTests(unittest.TestCase):
             # parent tries to sleep
             one_hundred_sec = 100000000
             t1 = time.time()
-            uid1 = c1.send_query("sleep", {"microseconds": one_hundred_sec, "state": state1})
+            uid1 = c1.send_query("sleep query", {"microseconds": one_hundred_sec, "state": state1})
             t2 = time.time()
         else:
             # child does not allow sleep


### PR DESCRIPTION
Makes it so that the handling of a notification cannot be interrupted/interleaved with new commands/queries/notifications. This may be enough to fix https://github.com/GaloisInc/cryptol/issues/1261

Tweaking the default state eviction policy to remove older requests automatically instead of reject new ones if the server is full (thus removing the need for scripts to call `reset` when connecting) may also be helpful.