### PR TITLE
chore: undo argo-client version bump

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -1,8 +1,3 @@
-# argo-client v0.0.8 (27 Aug 2021)
-+ Improvements related to notification/request interference
-  (i.e., when a single client sends a notification immediately
-   followed by a request).
-
 # argo-client v0.0.7 (25 Aug 2021)
 + Change the behavior of the `Command` `state` method so that after a `Command`
   raises an exception, subsequent interactions will not also raise the same

--- a/python/argo_client/connection.py
+++ b/python/argo_client/connection.py
@@ -11,7 +11,6 @@ import requests
 import socket
 import subprocess
 import signal
-import time
 import threading
 import sys
 from typing import Any, Dict, List, IO, Mapping, Optional, Union, TextIO

--- a/python/setup.py
+++ b/python/setup.py
@@ -12,7 +12,7 @@ def get_README():
 setup(
     name="argo-client",
     python_requires=">=3.7",
-    version="0.0.8",
+    version="0.0.7",
     url="https://github.com/GaloisInc/argo",
     project_urls={
         "Changelog": "https://github.com/GaloisInc/argo/blob/master/python/CHANGELOG.md",


### PR DESCRIPTION
6ca9206191197c938b9e63e4d06a65ef00092751 did not end up including changes that require a version bump for the argo client.