### PR TITLE
Allow building with aeson-2.0.*

### DIFF
--- a/argo/argo.cabal
+++ b/argo/argo.cabal
@@ -32,7 +32,7 @@ common warnings
 common deps
   build-depends:
     base                         >= 4.11.1.0 && < 4.16,
-    aeson                        >= 1.4.2,
+    aeson                        >= 1.4.2 && < 2.1,
     async                       ^>= 2.2,
     bytestring                  ^>= 0.10.8,
     containers                   >= 0.5.11 && <0.7,


### PR DESCRIPTION
I also added upper version bounds on `aeson` in `argo.cabal` to make this sort of breakage less likely to happen in the future.

Fixes #187.