### PR TITLE
Allow building with GHC 9.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc-ver: ["8.6.5", "8.8.4", "8.10.7", "9.0.2"]
+        ghc-ver: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.1"]
       # complete all jobs
       fail-fast: false
     name: Argo - GHC v${{ matrix.ghc-ver }} - ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc-ver: ["8.6.5", "8.8.4", "8.10.2", "9.0.1"]
+        ghc-ver: ["8.6.5", "8.8.4", "8.10.7", "9.0.2"]
       # complete all jobs
       fail-fast: false
     name: Argo - GHC v${{ matrix.ghc-ver }} - ubuntu-latest

--- a/argo/argo.cabal
+++ b/argo/argo.cabal
@@ -31,10 +31,10 @@ common warnings
 
 common deps
   build-depends:
-    base                         >= 4.11.1.0 && < 4.16,
+    base                         >= 4.11.1.0 && < 4.17,
     aeson                        >= 1.4.2 && < 2.1,
     async                       ^>= 2.2,
-    bytestring                  ^>= 0.10.8,
+    bytestring                   >= 0.10.8 && < 0.12,
     containers                   >= 0.5.11 && <0.7,
     directory                   ^>= 1.3,
     filelock                    ^>= 0.1,

--- a/file-echo-api/file-echo-api.cabal
+++ b/file-echo-api/file-echo-api.cabal
@@ -25,10 +25,10 @@ common warnings
 
 common deps
   build-depends:
-    base                 >=4.11.1.0 && <4.16,
+    base                 >=4.11.1.0 && <4.17,
     argo,
     aeson                >= 1.4.2,
-    bytestring           ^>= 0.10.8,
+    bytestring           >= 0.10.8 && < 0.12,
     containers           >=0.5.11 && <0.7,
     directory            ^>= 1.3.1,
     optparse-applicative >= 0.14 && < 0.17,


### PR DESCRIPTION
This raises the upper version bounds on `base` and `bytestring` to allow building with GHC 9.2.