### PR TITLE
CI: Upgrade Poetry version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         python-version: '3.11'
     - uses: abatilo/actions-poetry@v2.1.4
       with:
-        poetry-version: 1.1.11
+        poetry-version: 1.4.2
     - name: Checkout
       uses: actions/checkout@v2
       with:


### PR DESCRIPTION
The version we were previously using (1.1.11) is affected by this bug, causing invocations of Poetry to fail:
https://github.com/ionrock/cachecontrol/issues/292