### PR TITLE
Python: Use poetry.core.masonry.api as build-backend

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -26,4 +26,5 @@ urllib3 = ">=1.26.5"
 mypy = "^0.991"
 
 [build-system]
-requires = ["poetry>=1.1.4", "setuptools>=40.8.0"]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This is motivated by a desire to switch away from `setuptools`, which has some unfortunate interactions with static analysis tools.