### PR TITLE
Allow building with GHC 9.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc-ver: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.1","9.4.3"]
+        ghc-ver: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.8", "9.4.5"]
       # complete all jobs
       fail-fast: false
     name: Argo - GHC v${{ matrix.ghc-ver }} - ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         ghc-ver: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.8", "9.4.5", "9.6.2"]
+        cabal-ver: ["3.10.1.0"]
       # complete all jobs
       fail-fast: false
     name: Argo - GHC v${{ matrix.ghc-ver }} - ubuntu-latest
@@ -26,11 +27,12 @@ jobs:
       uses: actions/checkout@v2
       with:
         submodules: true
-    - name: Get GHC
+    - name: Get GHC and Cabal
       uses: haskell/actions/setup@v1
       id: setup-haskell
       with:
         ghc-version: ${{ matrix.ghc-ver }}
+        cabal-version: ${{ matrix.cabal-ver }}
     - uses: actions/cache/restore@v3
       name: Restore cabal store cache
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
       id: setup-haskell
       with:
         ghc-version: ${{ matrix.ghc-ver }}
-    - name: Cache
-      uses: actions/cache@v1
+    - uses: actions/cache/restore@v3
+      name: Restore cabal store cache
       with:
         path: /home/runner/.cabal/store/ghc-${{ matrix.ghc-ver }}
         # Prefer previous SHA hash if it is still cached
@@ -60,3 +60,10 @@ jobs:
     - name: Python argo-client unit tests
       working-directory: ./python
       run: poetry run python -m unittest discover --verbose tests
+    - uses: actions/cache/save@v3
+      name: Save cabal store cache
+      if: always()
+      with:
+        path: /home/runner/.cabal/store/ghc-${{ matrix.ghc-ver }}
+        # Prefer previous SHA hash if it is still cached
+        key: linux-${{ matrix.ghc-ver }}-${{ hashFiles('cabal.project.freeze') }}-${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc-ver: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.8", "9.4.5"]
+        ghc-ver: ["8.6.5", "8.8.4", "8.10.7", "9.0.2", "9.2.8", "9.4.5", "9.6.2"]
       # complete all jobs
       fail-fast: false
     name: Argo - GHC v${{ matrix.ghc-ver }} - ubuntu-latest

--- a/argo/argo.cabal
+++ b/argo/argo.cabal
@@ -31,8 +31,8 @@ common warnings
 
 common deps
   build-depends:
-    base                         >= 4.11.1.0 && < 4.18,
-    aeson                        >= 1.4.2 && < 2.2,
+    base                         >= 4.11.1.0 && < 4.19,
+    aeson                        >= 1.4.2 && < 2.3,
     async                       ^>= 2.2,
     bytestring                   >= 0.10.8 && < 0.12,
     containers                   >= 0.5.11 && <0.7,
@@ -41,9 +41,9 @@ common deps
     filepath                    ^>= 1.4,
     hashable                    >= 1.2 && < 1.5,
     http-types                  ^>= 0.12,
-    mtl                         ^>= 2.2,
+    mtl                         >= 2.2 && < 2.4,
     network                     >= 3.0.1,
-    optparse-applicative        >= 0.14 && < 0.17,
+    optparse-applicative        >= 0.14 && < 0.19,
     panic,
     safe                        ^>= 0.3,
     scientific                  ^>= 0.3,

--- a/argo/src/Argo/Doc.hs
+++ b/argo/src/Argo/Doc.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Argo.Doc (LinkTarget(..), Block(..), Inline(..), Described(..), DescribedMethod(..), datatype) where
 

--- a/file-echo-api/file-echo-api.cabal
+++ b/file-echo-api/file-echo-api.cabal
@@ -25,13 +25,13 @@ common warnings
 
 common deps
   build-depends:
-    base                 >=4.11.1.0 && <4.18,
+    base                 >=4.11.1.0 && <4.19,
     argo,
     aeson                >= 1.4.2,
     bytestring           >= 0.10.8 && < 0.12,
     containers           >=0.5.11 && <0.7,
     directory            ^>= 1.3.1,
-    optparse-applicative >= 0.14 && < 0.17,
+    optparse-applicative >= 0.14 && < 0.19,
     scientific           ^>= 0.3,
     text                 >= 1.2.3 && < 2.1,
     time,


### PR DESCRIPTION
This is a simple matter of bumping version bounds.

Along the way, I also fixed a warning uncovered with recent GHCs and updated the CI.