### PR TITLE
Allow building with GHC 9.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc-ver: ["8.8.4", "8.10.7", "9.0.2", "9.2.8", "9.4.5", "9.6.2"]
+        ghc-ver: ["8.8.4", "8.10.7", "9.0.2", "9.2.8", "9.4.5", "9.6.2", "9.8.1"]
         cabal-ver: ["3.10.1.0"]
       # complete all jobs
       fail-fast: false

--- a/argo/argo.cabal
+++ b/argo/argo.cabal
@@ -31,10 +31,10 @@ common warnings
 
 common deps
   build-depends:
-    base                         >= 4.13 && < 4.19,
+    base                         >= 4.13 && < 4.20,
     aeson                        >= 1.4.2 && < 2.3,
     async                       ^>= 2.2,
-    bytestring                   >= 0.10.8 && < 0.12,
+    bytestring                   >= 0.10.8 && < 0.13,
     containers                   >= 0.5.11 && <0.7,
     directory                   ^>= 1.3,
     filelock                    ^>= 0.1,
@@ -47,9 +47,9 @@ common deps
     panic,
     safe                        ^>= 0.3,
     scientific                  ^>= 0.3,
-    scotty                      ^>= 0.12,
+    scotty                      >= 0.12 && < 0.22,
     silently                    ^>= 1.2,
-    text                        >= 1.2.3 && < 2.1,
+    text                        >= 1.2.3 && < 2.2,
     unordered-containers        ^>= 0.2,
     uuid                        ^>= 1.3,
     warp                        >= 3.0.14,

--- a/file-echo-api/file-echo-api.cabal
+++ b/file-echo-api/file-echo-api.cabal
@@ -25,18 +25,18 @@ common warnings
 
 common deps
   build-depends:
-    base                 >=4.11.1.0 && <4.19,
+    base                 >=4.11.1.0 && <4.20,
     argo,
     aeson                >= 1.4.2,
-    bytestring           >= 0.10.8 && < 0.12,
+    bytestring           >= 0.10.8 && < 0.13,
     containers           >=0.5.11 && <0.7,
     directory            ^>= 1.3.1,
     optparse-applicative >= 0.14 && < 0.19,
     scientific           ^>= 0.3,
-    text                 >= 1.2.3 && < 2.1,
+    text                 >= 1.2.3 && < 2.2,
     time,
     unordered-containers ^>= 0.2,
-    vector               ^>= 0.12,
+    vector               ^>= 0.13,
 
   default-language:    Haskell2010
 


### PR DESCRIPTION
This bumps the upper version bounds on the `base`, `bytestring`, `scotty`, `text`, and `vector` libraries in order to support building with versions that are required by GHC 9.8.