### PR TITLE
Add `customMain` argument for `--version`-like global options

### DIFF
--- a/README-dist.rst
+++ b/README-dist.rst
@@ -8,7 +8,7 @@ convenient interaction with that API.
 Environment Setup
 =================
 
-The package contains two directories that external tools need ot be able
+The package contains two directories that external tools need to be able
 to find: `bin` and `python`. The former contains the server executables,
 and the latter contains Python code to make it convenient to interact
 with the servers.

--- a/argo/src/Argo/DefaultMain.hs
+++ b/argo/src/Argo/DefaultMain.hs
@@ -4,7 +4,10 @@ module Argo.DefaultMain
     defaultMain, customMain,
     -- * Options
     UserOptions(..),
-    userOptions) where
+    userOptions,
+    NoOpts(..),
+    parseNoOpts,
+  ) where
 
 import Control.Applicative ( Alternative((<|>)), (<**>) )
 import Control.Monad ( when )
@@ -92,8 +95,13 @@ defaultMain ::
 defaultMain str app =
   customMain parseNoOpts parseNoOpts parseNoOpts parseNoOpts str $ const $ pure app
 
+-- | A simple data type that represents the absence of additional command-line
+-- options (other than the default ones). See also 'parseNoOpts'.
 data NoOpts = NoOpts
 
+-- | Do not parse any additional command-line options (other than the default
+-- ones). This can be useful to pass to 'customMain' if you do not wish to
+-- customize a particular subcommand's command-line options further.
 parseNoOpts :: Opt.Parser NoOpts
 parseNoOpts = pure NoOpts
 

--- a/argo/src/Argo/DefaultMain.hs
+++ b/argo/src/Argo/DefaultMain.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE LambdaCase, OverloadedStrings, ScopedTypeVariables #-}
+{-# LANGUAGE LambdaCase, OverloadedStrings, RankNTypes, ScopedTypeVariables #-}
 module Argo.DefaultMain
   ( -- * Main functions
     defaultMain, customMain,
@@ -7,6 +7,7 @@ module Argo.DefaultMain
     userOptions,
     NoOpts(..),
     parseNoOpts,
+    parseNoTopLevelOpts
   ) where
 
 import Control.Applicative ( Alternative((<|>)), (<**>) )
@@ -70,15 +71,24 @@ customMain ::
   Opt.Parser socketOpts {- ^ A command-line parser for the options for socket mode -} ->
   Opt.Parser httpOpts {- ^ A command-line parser for the options for HTTP mode -} ->
   Opt.Parser docOpts {- ^ A command-line parser for the options for documenation -} ->
+  (forall a. Opt.Parser (a -> a))
+    {- ^ A command-line parser for top-level options. A common use case for
+         this parser is to configure options that only display messages
+         (e.g., @--version@). -}
+
+    {- Implementation note: we use a higher-rank type above so that the type
+       signature does not leak the GlobalOptions data type, which is an
+       implementation detail.
+    -} ->
   String {- ^ A description to be shown to users in the --help text -} ->
   (UserOptions stdIOOpts socketOpts httpOpts docOpts -> IO (App s))
     {- ^ An initialization procedure for the application that transforms the
          parsed custom options into an application -} ->
   IO ()
-customMain stdioOpts socketOpts httpOpts docOpts str app =
+customMain stdioOpts socketOpts httpOpts docOpts globalOpts str app =
   do opts <- Opt.customExecParser
                (Opt.prefs $ Opt.showHelpOnError <> Opt.showHelpOnEmpty)
-               (options stdioOpts socketOpts httpOpts docOpts str)
+               (options stdioOpts socketOpts httpOpts docOpts globalOpts str)
      case optLogFile $ methodOpts opts of
        Just path -> do
          alreadyExists <- doesFileExist path
@@ -93,7 +103,7 @@ defaultMain ::
   App s {- ^ The application to be run -} ->
   IO ()
 defaultMain str app =
-  customMain parseNoOpts parseNoOpts parseNoOpts parseNoOpts str $ const $ pure app
+  customMain parseNoOpts parseNoOpts parseNoOpts parseNoOpts parseNoTopLevelOpts str $ const $ pure app
 
 -- | A simple data type that represents the absence of additional command-line
 -- options (other than the default ones). See also 'parseNoOpts'.
@@ -104,6 +114,12 @@ data NoOpts = NoOpts
 -- customize a particular subcommand's command-line options further.
 parseNoOpts :: Opt.Parser NoOpts
 parseNoOpts = pure NoOpts
+
+-- | Do not parse any additional top-level command-line options (other than the
+-- default ones). This can be useful to pass to 'customMain' if you do not wish
+-- to customize the top-level application's command-line options further.
+parseNoTopLevelOpts :: Opt.Parser (a -> a)
+parseNoTopLevelOpts = pure id
 
 -- | Options that are common to the network server modes of operation,
 -- like socket and HTTP.
@@ -236,11 +252,13 @@ options ::
   Opt.Parser socketOpts ->
   Opt.Parser httpOpts ->
   Opt.Parser docOpts ->
+  (forall a. Opt.Parser (a -> a)) ->
   String ->
   Opt.ParserInfo (GlobalOptions stdioOpts socketOpts httpOpts docOpts)
-options stdioOpts socketOpts httpOpts docOpts desc =
-  (Opt.info (allOptions stdioOpts socketOpts httpOpts docOpts desc) $
-   Opt.fullDesc <> Opt.progDesc desc)
+options stdioOpts socketOpts httpOpts docOpts globalOpts desc =
+  Opt.info
+    (allOptions stdioOpts socketOpts httpOpts docOpts desc <**> globalOpts)
+    (Opt.fullDesc <> Opt.progDesc desc)
 
 hostOpt :: Opt.Parser (Maybe HostName)
 hostOpt =

--- a/file-echo-api/file-echo-api.cabal
+++ b/file-echo-api/file-echo-api.cabal
@@ -54,6 +54,8 @@ executable file-echo-api
   hs-source-dirs:      file-echo-api
   build-depends:
     file-echo-api
+  other-modules:
+    Paths_file_echo_api
 
 executable mutable-file-echo-api
   import:              deps, warnings
@@ -61,3 +63,5 @@ executable mutable-file-echo-api
   hs-source-dirs:      mutable-file-echo-api
   build-depends:
     file-echo-api
+  other-modules:
+    Paths_file_echo_api

--- a/file-echo-api/file-echo-api/Main.hs
+++ b/file-echo-api/file-echo-api/Main.hs
@@ -5,6 +5,7 @@
 module Main ( main ) where
 
 import Data.ByteString (ByteString)
+import Data.Version (showVersion)
 import Data.Typeable
 import qualified Options.Applicative as Opt
 
@@ -13,9 +14,10 @@ import qualified Argo.Doc as Doc
 import Argo.DefaultMain ( customMain, userOptions )
 
 import qualified FileEchoServer as FES
+import qualified Paths_file_echo_api
 
 main :: IO ()
-main = customMain parseServerOptions parseServerOptions parseServerOptions parseServerOptions description getApp
+main = customMain parseServerOptions parseServerOptions parseServerOptions parseServerOptions version description getApp
   where
     getApp opts =
       Argo.mkApp
@@ -51,6 +53,10 @@ parseServerOptions = ServerOptions <$> filename
       Opt.long "file" <>
       Opt.metavar "FILENAME" <>
       Opt.help "Initial file to echo"
+
+-- Display the version number when the --version option is supplied.
+version :: Opt.Parser (a -> a)
+version = Opt.simpleVersioner (showVersion Paths_file_echo_api.version)
 
 serverMethods :: [Argo.AppMethod FES.ServerState]
 serverMethods =

--- a/file-echo-api/mutable-file-echo-api/Main.hs
+++ b/file-echo-api/mutable-file-echo-api/Main.hs
@@ -5,6 +5,7 @@
 module Main ( main ) where
 
 import Data.ByteString (ByteString)
+import Data.Version (showVersion)
 import qualified Options.Applicative as Opt
 
 import qualified Argo as Argo
@@ -12,9 +13,10 @@ import qualified Argo.Doc as Doc
 import Argo.DefaultMain ( customMain, userOptions )
 
 import qualified MutableFileEchoServer as MFES
+import qualified Paths_file_echo_api
 
 main :: IO ()
-main = customMain parseServerOptions parseServerOptions parseServerOptions parseServerOptions description getApp
+main = customMain parseServerOptions parseServerOptions parseServerOptions parseServerOptions version description getApp
   where
     getApp opts =
       Argo.mkApp
@@ -49,6 +51,10 @@ parseServerOptions = ServerOptions <$> filename
       Opt.long "file" <>
       Opt.metavar "FILENAME" <>
       Opt.help "Initial file to echo"
+
+-- Display the version number when the --version option is supplied.
+version :: Opt.Parser (a -> a)
+version = Opt.simpleVersioner (showVersion Paths_file_echo_api.version)
 
 serverMethods :: [Argo.AppMethod MFES.ServerState]
 serverMethods =


### PR DESCRIPTION
`argo`'s allows users to customize the CLI option-parsing logic via the `customMain` function. The primary means to do so is by adding options for each subcommand (e.g., `stdio`). However, it is also convenient to allow users to specify global options for things that look like a `--version` option—i.e., that print some information and exit.

This patch enables this functionality by adding an extra `(forall a. Parser (a -> a))` argument to `customMain`, which can be used to configure global options that resemble `--version`. I have also updated the `file-echo-api` example applications in this repo to support a `--version` option, which provides a demonstration of how this functionality can be used.

Fixes https://github.com/GaloisInc/argo/issues/218.