### PR TITLE
Compile examples with `-threaded`, allow `time-manager-0.3.*`

### DIFF
--- a/argo/argo.cabal
+++ b/argo/argo.cabal
@@ -53,14 +53,7 @@ common deps
     unordered-containers        ^>= 0.2,
     uuid                        ^>= 1.3,
     warp                        >= 3.0.14,
-    warp-tls                    >= 3.1.0,
-    -- For now, we avoid building with time-manager-0.3.0 or later, as it
-    -- causes the argo test suite to regress.
-    --
-    -- TODO: Figure out what is causing this and resolve it so that we can use
-    -- a more recent time-manager version (see
-    -- https://github.com/yesodweb/wai/issues/1053).
-    time-manager                < 0.3
+    warp-tls                    >= 3.1.0
 
 
 library

--- a/file-echo-api/file-echo-api.cabal
+++ b/file-echo-api/file-echo-api.cabal
@@ -10,6 +10,10 @@ extra-source-files:  CHANGELOG.md
 data-files:          test-scripts/**/*.py
                      test-scripts/**/*.txt
 
+common rts
+  ghc-options:
+    -threaded
+
 common warnings
   ghc-options:
     -Wall
@@ -49,7 +53,7 @@ library
     MutableFileEchoServer
 
 executable file-echo-api
-  import:              deps, warnings
+  import:              deps, rts, warnings
   main-is:             Main.hs
   hs-source-dirs:      file-echo-api
   build-depends:
@@ -58,7 +62,7 @@ executable file-echo-api
     Paths_file_echo_api
 
 executable mutable-file-echo-api
-  import:              deps, warnings
+  import:              deps, rts, warnings
   main-is:             Main.hs
   hs-source-dirs:      mutable-file-echo-api
   build-depends:


### PR DESCRIPTION
This is a more robust fix for #227 that allows `argo` to build against `time-manager-0.3.*` instead of restricting the build to old `time-manager` versions. The new time manager implementation in `time-manager-0.3.*` currently requires `-threaded` (see https://github.com/yesodweb/wai/issues/1053#issuecomment-3728839511), so make sure that the executables in `file-echo-api.cabal` use this flag.