### PR TITLE
Allow building with GHC 9.12 (and 9.10)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc-ver: ["8.10.7", "9.0.2", "9.2.8", "9.4.5", "9.6.2", "9.8.1"]
+        ghc-ver: ["8.10.7", "9.0.2", "9.2.8", "9.4.5", "9.6.2", "9.8.1", "9.10.3", "9.12.2"]
         cabal-ver: ["3.10.1.0"]
       # complete all jobs
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,15 @@ on:
   pull_request:
     branches: [master]
 
+env:
+  # The CABAL_CACHE_VERSION environment variable can be updated to
+  # force the use of a new cabal cache if the current cache contents
+  # become corrupted/invalid.  This can sometimes happen when (for
+  # example) the OS version is changed but older .so files are cached,
+  # which can have various effects (e.g. cabal complains it can't find
+  # a valid version of the "happy" tool).
+  CABAL_CACHE_VERSION: 0
+
 jobs:
   build-linux:
     runs-on: ubuntu-latest
@@ -41,9 +50,9 @@ jobs:
           ${{ steps.setup-haskell.outputs.cabal-store }}
           dist-newstyle
         # Prefer previous SHA hash if it is still cached
-        key: linux-${{ matrix.ghc-ver }}-${{ hashFiles('cabal.project.freeze') }}-${{ github.sha }}
+        key: ${{ env.CABAL_CACHE_VERSION }}-linux-${{ matrix.ghc-ver }}-${{ hashFiles('cabal.project.freeze') }}-${{ github.sha }}
         # otherwise just use most recent build.
-        restore-keys: linux-${{ matrix.ghc-ver }}-${{ hashFiles('cabal.project.freeze') }}
+        restore-keys: ${{ env.CABAL_CACHE_VERSION }}-linux-${{ matrix.ghc-ver }}-${{ hashFiles('cabal.project.freeze') }}
     - name: Cabal update
       run: cabal update
       # Build macaw-base dependencies and crucible separately just so later
@@ -76,4 +85,4 @@ jobs:
           ${{ steps.setup-haskell.outputs.cabal-store }}
           dist-newstyle
         # Prefer previous SHA hash if it is still cached
-        key: linux-${{ matrix.ghc-ver }}-${{ hashFiles('cabal.project.freeze') }}-${{ github.sha }}
+        key: ${{ env.CABAL_CACHE_VERSION }}-linux-${{ matrix.ghc-ver }}-${{ hashFiles('cabal.project.freeze') }}-${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc-ver: ["8.10.7", "9.0.2", "9.2.8", "9.4.5", "9.6.2", "9.8.1", "9.10.3", "9.12.2"]
+        ghc-ver: ["8.10.7", "9.0.2", "9.2.8", "9.4.8", "9.6.7", "9.8.4", "9.10.3", "9.12.2"]
         cabal-ver: ["3.10.1.0"]
       # complete all jobs
       fail-fast: false

--- a/argo/argo.cabal
+++ b/argo/argo.cabal
@@ -31,15 +31,15 @@ common warnings
 
 common deps
   build-depends:
-    base                         >= 4.14 && < 4.20,
+    base                         >= 4.14 && < 4.22,
     aeson                        >= 1.4.2 && < 2.3,
     async                       ^>= 2.2,
     bytestring                   >= 0.10.8 && < 0.13,
-    containers                   >= 0.5.11 && <0.7,
+    containers                   >= 0.5.11 && <0.8,
     directory                   ^>= 1.3,
     filelock                    ^>= 0.1,
-    filepath                    ^>= 1.4,
-    hashable                    >= 1.2 && < 1.5,
+    filepath                    >= 1.4 && < 1.6,
+    hashable                    >= 1.2 && < 1.6,
     http-types                  ^>= 0.12,
     mtl                         >= 2.2 && < 2.4,
     network                     >= 3.0.1 && < 3.3,

--- a/file-echo-api/file-echo-api.cabal
+++ b/file-echo-api/file-echo-api.cabal
@@ -29,11 +29,11 @@ common warnings
 
 common deps
   build-depends:
-    base                 >=4.11.1.0 && <4.20,
+    base                 >=4.11.1.0 && <4.22,
     argo,
     aeson                >= 1.4.2,
     bytestring           >= 0.10.8 && < 0.13,
-    containers           >=0.5.11 && <0.7,
+    containers           >=0.5.11 && <0.8,
     directory            ^>= 1.3.1,
     optparse-applicative >= 0.14 && < 0.19,
     scientific           ^>= 0.3,


### PR DESCRIPTION
Bump upper version bounds on base, containers, and filepath to include the versions in those releases.